### PR TITLE
Fixed Card JSON and added SSML helper method

### DIFF
--- a/skillserver/echo.go
+++ b/skillserver/echo.go
@@ -77,6 +77,15 @@ func (this *EchoResponse) OutputSpeech(text string) *EchoResponse {
 	return this
 }
 
+func (this *EchoResponse) OutputSpeachSSML(text string) *EchoResponse {
+	this.Response.OutputSpeech = &EchoRespPayload{
+		Type: "SSML",
+		SSML: text,
+	}
+
+	return this
+}
+
 func (this *EchoResponse) Card(title string, content string) *EchoResponse {
 	this.Response.Card = &EchoRespPayload{
 		Type:  "Simple",
@@ -176,5 +185,6 @@ type EchoRespPayload struct {
 	Type    string `json:"type,omitempty"`
 	Title   string `json:"title,omitempty"`
 	Text    string `json:"text,omitempty"`
+	SSML    string `json:"ssml,omitempty"`
 	Content string `json:"content,omitempty"`
 }

--- a/skillserver/echo.go
+++ b/skillserver/echo.go
@@ -88,9 +88,9 @@ func (this *EchoResponse) OutputSpeachSSML(text string) *EchoResponse {
 
 func (this *EchoResponse) Card(title string, content string) *EchoResponse {
 	this.Response.Card = &EchoRespPayload{
-		Type:  "Simple",
-		Title: title,
-		Text:  content,
+		Type:    "Simple",
+		Title:   title,
+		Content: content,
 	}
 
 	return this


### PR DESCRIPTION
There was a bug in the Card method, it was putting the content into the Text JSON field instead of the Content JSON field.

I added a OutputSpeachSSML method to enable you to use SSML markup in the output speech instead of just plain text.
