### PR TITLE
Replace gorilla/context with new Go 1.7 context

### DIFF
--- a/skillserver/skillserver.go
+++ b/skillserver/skillserver.go
@@ -2,6 +2,7 @@ package skillserver
 
 import (
 	"bytes"
+	"context"
 	"crypto"
 	"crypto/rsa"
 	"crypto/sha1"
@@ -19,7 +20,6 @@ import (
 	"time"
 
 	"github.com/codegangsta/negroni"
-	"github.com/gorilla/context"
 	"github.com/gorilla/mux"
 )
 
@@ -59,7 +59,7 @@ func Init(apps map[string]interface{}, router *mux.Router) {
 		switch app := meta.(type) {
 		case EchoApplication:
 			handlerFunc := func(w http.ResponseWriter, r *http.Request) {
-				echoReq := context.Get(r, "echoRequest").(*EchoRequest)
+				echoReq := r.Context().Value("echoRequest").(*EchoRequest)
 				echoResp := NewEchoResponse()
 
 				if echoReq.GetRequestType() == "LaunchRequest" {
@@ -105,7 +105,7 @@ func Init(apps map[string]interface{}, router *mux.Router) {
 }
 
 func GetEchoRequest(r *http.Request) *EchoRequest {
-	return context.Get(r, "echoRequest").(*EchoRequest)
+	return r.Context().Value("echoRequest").(*EchoRequest)
 }
 
 func HTTPError(w http.ResponseWriter, logMsg string, err string, errCode int) {
@@ -137,7 +137,7 @@ func verifyJSON(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
 		return
 	}
 
-	context.Set(r, "echoRequest", echoReq)
+	r = r.WithContext(context.WithValue(r.Context(), "echoRequest", echoReq))
 
 	next(w, r)
 }


### PR DESCRIPTION
This fixes go-alexa under GoLang 1.7 (issue #7), by switching to using the stdlib HTTP [context](https://golang.org/pkg/net/http/#Request.Context) instead of [gorilla/context](https://github.com/gorilla/context). Not entirely sure how to merge this in in a backwards-compatible way however, as it'll break with any GoLang version pre-1.7.
