### PR TITLE
some changes for sessions/reprompts

### DIFF
--- a/skillserver/echo.go
+++ b/skillserver/echo.go
@@ -63,6 +63,7 @@ func NewEchoResponse() *EchoResponse {
 		Response: EchoRespBody{
 			ShouldEndSession: true,
 		},
+		SessionAttributes: make(map[string]interface{}),
 	}
 
 	return er

--- a/skillserver/echo.go
+++ b/skillserver/echo.go
@@ -137,6 +137,17 @@ func (this *EchoResponse) Reprompt(text string) *EchoResponse {
 	return this
 }
 
+func (this *EchoResponse) RepromptSSML(text string) *EchoResponse {
+	this.Response.Reprompt = &EchoReprompt{
+		OutputSpeech: EchoRespPayload{
+			Type: "SSML",
+			Text: text,
+		},
+	}
+
+	return this
+}
+
 func (this *EchoResponse) EndSession(flag bool) *EchoResponse {
 	this.Response.ShouldEndSession = flag
 

--- a/skillserver/echo.go
+++ b/skillserver/echo.go
@@ -166,10 +166,8 @@ type EchoSession struct {
 	Application struct {
 		ApplicationID string `json:"applicationId"`
 	} `json:"application"`
-	Attributes struct {
-		String map[string]interface{} `json:"string"`
-	} `json:"attributes"`
-	User struct {
+	Attributes map[string]interface{} `json:"attributes"`
+	User       struct {
 		UserID      string `json:"userId"`
 		AccessToken string `json:"accessToken,omitempty"`
 	} `json:"user"`


### PR DESCRIPTION
couple changes:
1. request session had an invalid map attribute called `String`. This should be a map.
2. response wasn't initializing session map
3. I wanted to use SSML for reprompt