### PR TITLE
Update SSML package with parameter validation, documentation, & examples

### DIFF
--- a/skillserver/ssml-builder.go
+++ b/skillserver/ssml-builder.go
@@ -12,14 +12,17 @@ import (
 
 // Helper Types
 
+// Deprecated: Please use the github.com/mikeflynn/go-alexa/ssml package
 type SSMLTextBuilder struct {
 	buffer *bytes.Buffer
 }
 
+// Deprecated: Please use the github.com/mikeflynn/go-alexa/ssml package
 func NewSSMLTextBuilder() *SSMLTextBuilder {
 	return &SSMLTextBuilder{bytes.NewBufferString("")}
 }
 
+// Deprecated: Please use the github.com/mikeflynn/go-alexa/ssml package
 func (builder *SSMLTextBuilder) AppendPlainSpeech(text string) *SSMLTextBuilder {
 
 	builder.buffer.WriteString(text)
@@ -27,6 +30,7 @@ func (builder *SSMLTextBuilder) AppendPlainSpeech(text string) *SSMLTextBuilder 
 	return builder
 }
 
+// Deprecated: Please use the github.com/mikeflynn/go-alexa/ssml package
 func (builder *SSMLTextBuilder) AppendAmazonEffect(text, name string) *SSMLTextBuilder {
 
 	builder.buffer.WriteString(fmt.Sprintf("<amazon:effect name=\"%s\">%s</amazon:effect>", name, text))
@@ -34,6 +38,7 @@ func (builder *SSMLTextBuilder) AppendAmazonEffect(text, name string) *SSMLTextB
 	return builder
 }
 
+// Deprecated: Please use the github.com/mikeflynn/go-alexa/ssml package
 func (builder *SSMLTextBuilder) AppendAudio(src string) *SSMLTextBuilder {
 
 	builder.buffer.WriteString(fmt.Sprintf("<audio src=\"%s\"/>", src))
@@ -41,6 +46,7 @@ func (builder *SSMLTextBuilder) AppendAudio(src string) *SSMLTextBuilder {
 	return builder
 }
 
+// Deprecated: Please use the github.com/mikeflynn/go-alexa/ssml package
 func (builder *SSMLTextBuilder) AppendBreak(strength, time string) *SSMLTextBuilder {
 
 	if strength == "" {
@@ -53,6 +59,7 @@ func (builder *SSMLTextBuilder) AppendBreak(strength, time string) *SSMLTextBuil
 	return builder
 }
 
+// Deprecated: Please use the github.com/mikeflynn/go-alexa/ssml package
 func (builder *SSMLTextBuilder) AppendEmphasis(text, level string) *SSMLTextBuilder {
 
 	builder.buffer.WriteString(fmt.Sprintf("<emphasis level=\"%s\">%s</emphasis>", level, text))
@@ -60,6 +67,7 @@ func (builder *SSMLTextBuilder) AppendEmphasis(text, level string) *SSMLTextBuil
 	return builder
 }
 
+// Deprecated: Please use the github.com/mikeflynn/go-alexa/ssml package
 func (builder *SSMLTextBuilder) AppendParagraph(text string) *SSMLTextBuilder {
 
 	builder.buffer.WriteString(fmt.Sprintf("<p>%s</p>", text))
@@ -67,6 +75,7 @@ func (builder *SSMLTextBuilder) AppendParagraph(text string) *SSMLTextBuilder {
 	return builder
 }
 
+// Deprecated: Please use the github.com/mikeflynn/go-alexa/ssml package
 func (builder *SSMLTextBuilder) AppendProsody(text, rate, pitch, volume string) *SSMLTextBuilder {
 
 	builder.buffer.WriteString(fmt.Sprintf("<prosody rate=\"%s\" pitch=\"%s\" volume=\"%s\">%s</prosody>", rate, pitch, volume, text))
@@ -74,6 +83,7 @@ func (builder *SSMLTextBuilder) AppendProsody(text, rate, pitch, volume string) 
 	return builder
 }
 
+// Deprecated: Please use the github.com/mikeflynn/go-alexa/ssml package
 func (builder *SSMLTextBuilder) AppendSentence(text string) *SSMLTextBuilder {
 
 	builder.buffer.WriteString(fmt.Sprintf("<s>%s</s>", text))
@@ -81,6 +91,7 @@ func (builder *SSMLTextBuilder) AppendSentence(text string) *SSMLTextBuilder {
 	return builder
 }
 
+// Deprecated: Please use the github.com/mikeflynn/go-alexa/ssml package
 func (builder *SSMLTextBuilder) AppendSubstitution(text, alias string) *SSMLTextBuilder {
 
 	builder.buffer.WriteString(fmt.Sprintf("<sub alias=\"%s\">%s</sub>", alias, text))
@@ -88,6 +99,7 @@ func (builder *SSMLTextBuilder) AppendSubstitution(text, alias string) *SSMLText
 	return builder
 }
 
+// Deprecated: Please use the github.com/mikeflynn/go-alexa/ssml package
 func (builder *SSMLTextBuilder) Build() string {
 	return fmt.Sprintf("<speak>%s</speak>", builder.buffer.String())
 }

--- a/ssml/builder.go
+++ b/ssml/builder.go
@@ -16,56 +16,56 @@ import (
  * https://developer.amazon.com/public/solutions/alexa/alexa-skills-kit/docs/speech-synthesis-markup-language-ssml-reference
  */
 
-func NewBuilder() (*builder, error) {
-	return &builder{bytes.NewBufferString("")}, nil
+func NewBuilder() (*Builder, error) {
+	return &Builder{bytes.NewBufferString("")}, nil
 }
 
-func (builder *builder) AppendPlainSpeech(text string) (*builder, error) {
+func (builder *Builder) AppendPlainSpeech(text string) (*Builder, error) {
 	builder.buffer.WriteString(text)
 	return builder, nil
 }
 
-func (builder *builder) AppendAmazonEffect(effect amazoneffect.Effect, text string) (*builder, error) {
+func (builder *Builder) AppendAmazonEffect(effect amazoneffect.Effect, text string) (*Builder, error) {
 	builder.buffer.WriteString(fmt.Sprintf("<amazon:effect name=\"%s\">%s</amazon:effect>", effect, text))
 	return builder, nil
 }
 
-func (builder *builder) AppendAudio(src string) (*builder, error) {
+func (builder *Builder) AppendAudio(src string) (*Builder, error) {
 	builder.buffer.WriteString(fmt.Sprintf("<audio src=\"%s\"/>", src))
 	return builder, nil
 }
 
-func (builder *builder) AppendBreak(strength pause.Strength, duration time.Duration) (*builder, error) {
+func (builder *Builder) AppendBreak(strength pause.Strength, duration time.Duration) (*Builder, error) {
 	durationMs := duration.Nanoseconds() / 1e6
 	builder.buffer.WriteString(fmt.Sprintf("<break strength=\"%s\" time=\"%dms\"/>", strength, durationMs))
 	return builder, nil
 }
 
-func (builder *builder) AppendEmphasis(level emphasis.Level, text string) (*builder, error) {
+func (builder *Builder) AppendEmphasis(level emphasis.Level, text string) (*Builder, error) {
 	builder.buffer.WriteString(fmt.Sprintf("<emphasis level=\"%s\">%s</emphasis>", level, text))
 	return builder, nil
 }
 
-func (builder *builder) AppendParagraph(text string) (*builder, error) {
+func (builder *Builder) AppendParagraph(text string) (*Builder, error) {
 	builder.buffer.WriteString(fmt.Sprintf("<p>%s</p>", text))
 	return builder, nil
 }
 
-func (builder *builder) AppendProsody(rate prosody.Rate, pitch prosody.Pitch, volume prosody.Volume, text string) (*builder, error) {
+func (builder *Builder) AppendProsody(rate prosody.Rate, pitch prosody.Pitch, volume prosody.Volume, text string) (*Builder, error) {
 	builder.buffer.WriteString(fmt.Sprintf("<prosody rate=\"%s\" pitch=\"%s\" volume=\"%s\">%s</prosody>", rate, pitch, volume, text))
 	return builder, nil
 }
 
-func (builder *builder) AppendSentence(text string) (*builder, error) {
+func (builder *Builder) AppendSentence(text string) (*Builder, error) {
 	builder.buffer.WriteString(fmt.Sprintf("<s>%s</s>", text))
 	return builder, nil
 }
 
-func (builder *builder) AppendSubstitution(alias, text string) (*builder, error) {
+func (builder *Builder) AppendSubstitution(alias, text string) (*Builder, error) {
 	builder.buffer.WriteString(fmt.Sprintf("<sub alias=\"%s\">%s</sub>", alias, text))
 	return builder, nil
 }
 
-func (builder *builder) Build() string {
+func (builder *Builder) Build() string {
 	return fmt.Sprintf("<speak>%s</speak>", builder.buffer.String())
 }

--- a/ssml/builder.go
+++ b/ssml/builder.go
@@ -4,79 +4,86 @@ import (
 	"bytes"
 	"fmt"
 	"net/url"
-	"strings"
 	"time"
 
 	"github.com/mikeflynn/go-alexa/ssml/amazoneffect"
 	"github.com/mikeflynn/go-alexa/ssml/emphasis"
 	"github.com/mikeflynn/go-alexa/ssml/pause"
 	"github.com/mikeflynn/go-alexa/ssml/prosody"
+	"github.com/pkg/errors"
 )
 
 // NewBuilder returns an empty new SSML builder.
 func NewBuilder() (*Builder, error) {
-	return &Builder{bytes.NewBufferString("")}, nil
+	return &Builder{
+		buffer: bytes.NewBufferString(""),
+	}, nil
 }
 
 // AppendPlainSpeech appends raw text to the builder's internal SSML string.
-// It returns a nil error.
-func (builder *Builder) AppendPlainSpeech(text string) error {
+// It will not append an error to the builder's internal error slice.
+// It returns a pointer to the builder
+func (builder *Builder) AppendPlainSpeech(text string) *Builder {
 	builder.buffer.WriteString(text)
-	return nil
+	return builder
 }
 
 // AppendAmazonEffect appends an AmazonEffect to the builder's internal SSML string.
 // Valid Effects can be found in the amazoneffect sub-package.
-// It returns a nil error.
-func (builder *Builder) AppendAmazonEffect(effect amazoneffect.Effect, text string) error {
+// It will not append an error to the builder's internal error slice.
+// It returns a pointer to the builder
+func (builder *Builder) AppendAmazonEffect(effect amazoneffect.Effect, text string) *Builder {
 	builder.buffer.WriteString(fmt.Sprintf("<amazon:effect name=\"%s\">%s</amazon:effect>", effect, text))
-	return nil
+	return builder
 }
 
 // AppendAmazonEffect appends an audio element to the builder's internal SSML string.
-// src must be a valid HTTPS url.
-// It returns an error if the src is an invalid URL.
-func (builder *Builder) AppendAudio(src string) error {
+// It will append an error to the builder's internal error slice if the src is an invalid URL or not a HTTPs URL.
+// It returns a pointer to the builder.
+func (builder *Builder) AppendAudio(src string) *Builder {
 	u, err := url.Parse(src)
 	if err != nil {
-		return fmt.Errorf("src failed to parse into a valid URL: %v", err)
+		return builder.appendError(fmt.Errorf("src failed to parse into a valid URL: %v", err))
 	}
 	if u.Scheme != "https" {
-		return fmt.Errorf("src must be a HTTPS URL. Scheme %s not valid", u.Scheme)
+		return builder.appendError(fmt.Errorf("src must be a HTTPS URL: Scheme %s not valid", u.Scheme))
 	}
 	builder.buffer.WriteString(fmt.Sprintf("<audio src=\"%s\"/>", u.String()))
-	return nil
+	return builder
 }
 
 // AppendAmazonEffect appends a break/pause element to the builder's internal SSML string.
 // strengthOrDuration must either be of type Strength (from the pause sub-package) or time.Duration.
-// It returns an error if strengthOrDuration is of an invalid type.
-func (builder *Builder) AppendBreak(strengthOrDuration interface{}) error {
+// It will append an error to the builder's internal error slice if strengthOrDuration is of an invalid type.
+// It returns a pointer to the builder.
+func (builder *Builder) AppendBreak(strengthOrDuration interface{}) *Builder {
 	strength, ok := strengthOrDuration.(pause.Strength)
 	if !ok {
 		duration, ok := strengthOrDuration.(time.Duration)
 		if !ok {
-			return fmt.Errorf("unsupported parameter type. must be either pause.Strength or time.Duration")
+			return builder.appendError(errors.New("unsupported parameter type: must be either pause.Strength or time.Duration"))
 		}
 		builder.buffer.WriteString(fmt.Sprintf("<break time=\"%dms\"/>", duration.Nanoseconds()/1e6))
-		return nil
+		return builder
 	}
 	builder.buffer.WriteString(fmt.Sprintf("<break strength=\"%s\"/>", strength))
-	return nil
+	return builder
 }
 
 // AppendEmphasis appends an emphasis element to the builder's internal SSML string.
-// It returns a nil error.
-func (builder *Builder) AppendEmphasis(level emphasis.Level, text string) error {
+// It will not append an error to the builder's internal error slice.
+// It returns a pointer to the builder
+func (builder *Builder) AppendEmphasis(level emphasis.Level, text string) *Builder {
 	builder.buffer.WriteString(fmt.Sprintf("<emphasis level=\"%s\">%s</emphasis>", level, text))
-	return nil
+	return builder
 }
 
 // AppendParagraph appends a paragraph element to the builder's internal SSML string.
-// It returns a nil error.
-func (builder *Builder) AppendParagraph(text string) error {
+// It will not append an error to the builder's internal error slice.
+// It returns a pointer to the builder.
+func (builder *Builder) AppendParagraph(text string) *Builder {
 	builder.buffer.WriteString(fmt.Sprintf("<p>%s</p>", text))
-	return nil
+	return builder
 }
 
 // AppendProsody appends a prosody element to the builder's internal SSML string.
@@ -87,18 +94,18 @@ func (builder *Builder) AppendParagraph(text string) error {
 // volume must either be nil or a Volume (from the prosody.Volume sub-package) or an int. If nil no volume value is
 // included in the prosody element.
 // It returns an error if a parameter is of an invalid type.
-func (builder *Builder) AppendProsody(rate, pitch, volume interface{}, text string) error {
+func (builder *Builder) AppendProsody(rate, pitch, volume interface{}, text string) *Builder {
 	src := ""
 	if rate != nil {
 		rateStr, ok := rate.(prosody.Rate)
 		if !ok {
 			ratePercent, ok := rate.(int)
 			if !ok {
-				return fmt.Errorf("unsupported rate type. must be either prosody.Rate or int")
+				return builder.appendError(errors.New("unsupported rate type: must be either prosody.Rate or int"))
 			}
-			src += fmt.Sprintf("rate=\"%d%%\" ", ratePercent)
+			src += fmt.Sprintf(" rate=\"%d%%\"", ratePercent)
 		} else {
-			src += fmt.Sprintf("rate=\"%s\" ", rateStr)
+			src += fmt.Sprintf(" rate=\"%s\"", rateStr)
 		}
 	}
 
@@ -107,15 +114,15 @@ func (builder *Builder) AppendProsody(rate, pitch, volume interface{}, text stri
 		if !ok {
 			pitchPercent, ok := pitch.(int)
 			if !ok {
-				return fmt.Errorf("unsupported pitch type. must be either prosody.Pitch or int")
+				return builder.appendError(errors.New("unsupported pitch type: must be either prosody.Pitch or int"))
 			}
 			sign := ""
 			if pitchPercent > 0 {
 				sign = "+"
 			}
-			src += fmt.Sprintf("pitch=\"%s%d%%\" ", sign, pitchPercent)
+			src += fmt.Sprintf(" pitch=\"%s%d%%\"", sign, pitchPercent)
 		} else {
-			src += fmt.Sprintf("pitch=\"%s\" ", pitchStr)
+			src += fmt.Sprintf(" pitch=\"%s\"", pitchStr)
 		}
 	}
 
@@ -124,20 +131,20 @@ func (builder *Builder) AppendProsody(rate, pitch, volume interface{}, text stri
 		if !ok {
 			volumeDb, ok := volume.(int)
 			if !ok {
-				return fmt.Errorf("unsupported volume type. must be either prosody.Volume or int")
+				return builder.appendError(errors.New("unsupported volume type: must be either prosody.Volume or int"))
 			}
 			sign := ""
 			if volumeDb > 0 {
 				sign = "+"
 			}
-			src += fmt.Sprintf("volume=\"%s%ddB\" ", sign, volumeDb)
+			src += fmt.Sprintf(" volume=\"%s%ddB\"", sign, volumeDb)
 		} else {
-			src += fmt.Sprintf("volume=\"%s\" ", volumeStr)
+			src += fmt.Sprintf(" volume=\"%s\"", volumeStr)
 		}
 	}
 
-	builder.buffer.WriteString(fmt.Sprintf("<prosody %s>%s</prosody>", strings.TrimSpace(src), text))
-	return nil
+	builder.buffer.WriteString(fmt.Sprintf("<prosody%s>%s</prosody>", src, text))
+	return builder
 }
 
 // AppendSentence appends a sentence element to the builder's internal SSML string.
@@ -156,6 +163,15 @@ func (builder *Builder) AppendSubstitution(alias, text string) error {
 
 // Build builds the SSML string.
 // It returns the SSML string.
-func (builder *Builder) Build() string {
-	return fmt.Sprintf("<speak>%s</speak>", builder.buffer.String())
+func (builder *Builder) Build() (string, []error) {
+	builder.lock.RLock()
+	defer builder.lock.RUnlock()
+	return fmt.Sprintf("<speak>%s</speak>", builder.buffer.String()), builder.errs
+}
+
+func (builder *Builder) appendError(err error) *Builder {
+	builder.lock.Lock()
+	defer builder.lock.Unlock()
+	builder.errs = append(builder.errs, err)
+	return builder
 }

--- a/ssml/builder.go
+++ b/ssml/builder.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"time"
 
+	"net/url"
+
 	"github.com/mikeflynn/go-alexa/ssml/amazoneffect"
 	"github.com/mikeflynn/go-alexa/ssml/emphasis"
 	"github.com/mikeflynn/go-alexa/ssml/pause"
@@ -30,10 +32,17 @@ func (builder *Builder) AppendAmazonEffect(effect amazoneffect.Effect, text stri
 }
 
 // AppendAmazonEffect appends an audio element to the builder's internal SSML string.
+// src must be a valid HTTPS url.
 // It returns the builder pointer and an error if the src is an invalid URL.
-// TODO: Validate src
 func (builder *Builder) AppendAudio(src string) (*Builder, error) {
-	builder.buffer.WriteString(fmt.Sprintf("<audio src=\"%s\"/>", src))
+	u, err := url.Parse(src)
+	if err != nil {
+		return nil, fmt.Errorf("src failed to parse into a valid URL: %v", err)
+	}
+	if u.Scheme != "https" {
+		return nil, fmt.Errorf("src must be a HTTPS URL. Scheme %s not valid", u.Scheme)
+	}
+	builder.buffer.WriteString(fmt.Sprintf("<audio src=\"%s\"/>", u.String()))
 	return builder, nil
 }
 

--- a/ssml/builder.go
+++ b/ssml/builder.go
@@ -116,11 +116,13 @@ func (builder *Builder) AppendProsody(rate, pitch, volume interface{}, text stri
 			if !ok {
 				return builder.appendError(errors.New("unsupported pitch type: must be either prosody.Pitch or int"))
 			}
-			sign := ""
+
 			if pitchPercent > 0 {
-				sign = "+"
+				src += fmt.Sprintf(" pitch=\"+%d%%\"", pitchPercent)
+			} else {
+				src += fmt.Sprintf(" pitch=\"%d%%\"", pitchPercent)
 			}
-			src += fmt.Sprintf(" pitch=\"%s%d%%\"", sign, pitchPercent)
+
 		} else {
 			src += fmt.Sprintf(" pitch=\"%s\"", pitchStr)
 		}
@@ -133,11 +135,11 @@ func (builder *Builder) AppendProsody(rate, pitch, volume interface{}, text stri
 			if !ok {
 				return builder.appendError(errors.New("unsupported volume type: must be either prosody.Volume or int"))
 			}
-			sign := ""
 			if volumeDb > 0 {
-				sign = "+"
+				src += fmt.Sprintf(" volume=\"+%ddB\"", volumeDb)
+			} else {
+				src += fmt.Sprintf(" volume=\"%ddB\"", volumeDb)
 			}
-			src += fmt.Sprintf(" volume=\"%s%ddB\"", sign, volumeDb)
 		} else {
 			src += fmt.Sprintf(" volume=\"%s\"", volumeStr)
 		}

--- a/ssml/builder.go
+++ b/ssml/builder.go
@@ -11,25 +11,35 @@ import (
 	"github.com/mikeflynn/go-alexa/ssml/prosody"
 )
 
+// NewBuilder returns an empty new SSML builder.
 func NewBuilder() (*Builder, error) {
 	return &Builder{bytes.NewBufferString("")}, nil
 }
 
+// AppendPlainSpeech appends raw text to the builder's internal SSML string.
 func (builder *Builder) AppendPlainSpeech(text string) (*Builder, error) {
 	builder.buffer.WriteString(text)
 	return builder, nil
 }
 
+// AppendAmazonEffect appends an AmazonEffect to the builder's internal SSML string.
+// Valid Effects can be found in the amazoneffect sub-package
 func (builder *Builder) AppendAmazonEffect(effect amazoneffect.Effect, text string) (*Builder, error) {
 	builder.buffer.WriteString(fmt.Sprintf("<amazon:effect name=\"%s\">%s</amazon:effect>", effect, text))
 	return builder, nil
 }
 
+// AppendAmazonEffect appends an audio element to the builder's internal SSML string.
+// It returns the builder pointer and an error if the src is an invalid URL.
+// TODO: Validate src
 func (builder *Builder) AppendAudio(src string) (*Builder, error) {
 	builder.buffer.WriteString(fmt.Sprintf("<audio src=\"%s\"/>", src))
 	return builder, nil
 }
 
+// AppendAmazonEffect appends a break/pause element to the builder's internal SSML string.
+// strengthOrDuration must either be of type Strength (from the pause sub-package) or time.Duration
+// It returns the builder pointer and an error if strengthOrDuration is of an invalid type
 func (builder *Builder) AppendBreak(strengthOrDuration interface{}) (*Builder, error) {
 	strength, ok := strengthOrDuration.(pause.Strength)
 	if !ok {
@@ -44,31 +54,44 @@ func (builder *Builder) AppendBreak(strengthOrDuration interface{}) (*Builder, e
 	return builder, nil
 }
 
+// AppendEmphasis appends an emphasis element to the builder's internal SSML string.
+// It returns the builder pointer and a nil error.
 func (builder *Builder) AppendEmphasis(level emphasis.Level, text string) (*Builder, error) {
 	builder.buffer.WriteString(fmt.Sprintf("<emphasis level=\"%s\">%s</emphasis>", level, text))
 	return builder, nil
 }
 
+// AppendParagraph appends a paragraph element to the builder's internal SSML string.
+// It returns the builder pointer and a nil error.
 func (builder *Builder) AppendParagraph(text string) (*Builder, error) {
 	builder.buffer.WriteString(fmt.Sprintf("<p>%s</p>", text))
 	return builder, nil
 }
 
+// AppendProsody appends a prosody element to the builder's internal SSML string.
+// It returns the builder pointer and an error if any parameters fall outside their accepted ranges.
+// TODO: Validate parameters
 func (builder *Builder) AppendProsody(rate prosody.Rate, pitch prosody.Pitch, volume prosody.Volume, text string) (*Builder, error) {
 	builder.buffer.WriteString(fmt.Sprintf("<prosody rate=\"%s\" pitch=\"%s\" volume=\"%s\">%s</prosody>", rate, pitch, volume, text))
 	return builder, nil
 }
 
+// AppendSentence appends a sentence element to the builder's internal SSML string.
+// It returns the builder pointer and a nil error.
 func (builder *Builder) AppendSentence(text string) (*Builder, error) {
 	builder.buffer.WriteString(fmt.Sprintf("<s>%s</s>", text))
 	return builder, nil
 }
 
+// AppendSubstitution appends a substitution element to the builder's internal SSML string.
+// It returns the builder pointer and a nil error.
 func (builder *Builder) AppendSubstitution(alias, text string) (*Builder, error) {
 	builder.buffer.WriteString(fmt.Sprintf("<sub alias=\"%s\">%s</sub>", alias, text))
 	return builder, nil
 }
 
+// Build builds the SSML string.
+// It returns the SSML string.
 func (builder *Builder) Build() string {
 	return fmt.Sprintf("<speak>%s</speak>", builder.buffer.String())
 }

--- a/ssml/builder.go
+++ b/ssml/builder.go
@@ -26,7 +26,7 @@ func (builder *Builder) AppendPlainSpeech(text string) error {
 }
 
 // AppendAmazonEffect appends an AmazonEffect to the builder's internal SSML string.
-// Valid Effects can be found in the amazoneffect sub-package
+// Valid Effects can be found in the amazoneffect sub-package.
 // It returns a nil error.
 func (builder *Builder) AppendAmazonEffect(effect amazoneffect.Effect, text string) error {
 	builder.buffer.WriteString(fmt.Sprintf("<amazon:effect name=\"%s\">%s</amazon:effect>", effect, text))
@@ -49,8 +49,8 @@ func (builder *Builder) AppendAudio(src string) error {
 }
 
 // AppendAmazonEffect appends a break/pause element to the builder's internal SSML string.
-// strengthOrDuration must either be of type Strength (from the pause sub-package) or time.Duration
-// It returns an error if strengthOrDuration is of an invalid type
+// strengthOrDuration must either be of type Strength (from the pause sub-package) or time.Duration.
+// It returns an error if strengthOrDuration is of an invalid type.
 func (builder *Builder) AppendBreak(strengthOrDuration interface{}) error {
 	strength, ok := strengthOrDuration.(pause.Strength)
 	if !ok {

--- a/ssml/builder.go
+++ b/ssml/builder.go
@@ -19,62 +19,64 @@ func NewBuilder() (*Builder, error) {
 }
 
 // AppendPlainSpeech appends raw text to the builder's internal SSML string.
-func (builder *Builder) AppendPlainSpeech(text string) (*Builder, error) {
+// It returns a nil error.
+func (builder *Builder) AppendPlainSpeech(text string) error {
 	builder.buffer.WriteString(text)
-	return builder, nil
+	return nil
 }
 
 // AppendAmazonEffect appends an AmazonEffect to the builder's internal SSML string.
 // Valid Effects can be found in the amazoneffect sub-package
-func (builder *Builder) AppendAmazonEffect(effect amazoneffect.Effect, text string) (*Builder, error) {
+// It returns a nil error.
+func (builder *Builder) AppendAmazonEffect(effect amazoneffect.Effect, text string) error {
 	builder.buffer.WriteString(fmt.Sprintf("<amazon:effect name=\"%s\">%s</amazon:effect>", effect, text))
-	return builder, nil
+	return nil
 }
 
 // AppendAmazonEffect appends an audio element to the builder's internal SSML string.
 // src must be a valid HTTPS url.
-// It returns the builder pointer and an error if the src is an invalid URL.
-func (builder *Builder) AppendAudio(src string) (*Builder, error) {
+// It returns an error if the src is an invalid URL.
+func (builder *Builder) AppendAudio(src string) error {
 	u, err := url.Parse(src)
 	if err != nil {
-		return nil, fmt.Errorf("src failed to parse into a valid URL: %v", err)
+		return fmt.Errorf("src failed to parse into a valid URL: %v", err)
 	}
 	if u.Scheme != "https" {
-		return nil, fmt.Errorf("src must be a HTTPS URL. Scheme %s not valid", u.Scheme)
+		return fmt.Errorf("src must be a HTTPS URL. Scheme %s not valid", u.Scheme)
 	}
 	builder.buffer.WriteString(fmt.Sprintf("<audio src=\"%s\"/>", u.String()))
-	return builder, nil
+	return nil
 }
 
 // AppendAmazonEffect appends a break/pause element to the builder's internal SSML string.
 // strengthOrDuration must either be of type Strength (from the pause sub-package) or time.Duration
-// It returns the builder pointer and an error if strengthOrDuration is of an invalid type
-func (builder *Builder) AppendBreak(strengthOrDuration interface{}) (*Builder, error) {
+// It returns an error if strengthOrDuration is of an invalid type
+func (builder *Builder) AppendBreak(strengthOrDuration interface{}) error {
 	strength, ok := strengthOrDuration.(pause.Strength)
 	if !ok {
 		duration, ok := strengthOrDuration.(time.Duration)
 		if !ok {
-			return builder, fmt.Errorf("unsupported parameter type. must be either pause.Strength or time.Duration")
+			return fmt.Errorf("unsupported parameter type. must be either pause.Strength or time.Duration")
 		}
 		builder.buffer.WriteString(fmt.Sprintf("<break time=\"%dms\"/>", duration.Nanoseconds()/1e6))
-		return builder, nil
+		return nil
 	}
 	builder.buffer.WriteString(fmt.Sprintf("<break strength=\"%s\"/>", strength))
-	return builder, nil
+	return nil
 }
 
 // AppendEmphasis appends an emphasis element to the builder's internal SSML string.
-// It returns the builder pointer and a nil error.
-func (builder *Builder) AppendEmphasis(level emphasis.Level, text string) (*Builder, error) {
+// It returns a nil error.
+func (builder *Builder) AppendEmphasis(level emphasis.Level, text string) error {
 	builder.buffer.WriteString(fmt.Sprintf("<emphasis level=\"%s\">%s</emphasis>", level, text))
-	return builder, nil
+	return nil
 }
 
 // AppendParagraph appends a paragraph element to the builder's internal SSML string.
-// It returns the builder pointer and a nil error.
-func (builder *Builder) AppendParagraph(text string) (*Builder, error) {
+// It returns a nil error.
+func (builder *Builder) AppendParagraph(text string) error {
 	builder.buffer.WriteString(fmt.Sprintf("<p>%s</p>", text))
-	return builder, nil
+	return nil
 }
 
 // AppendProsody appends a prosody element to the builder's internal SSML string.
@@ -84,15 +86,15 @@ func (builder *Builder) AppendParagraph(text string) (*Builder, error) {
 // included in the prosody element.
 // volume must either be nil or a Volume (from the prosody.Volume sub-package) or an int. If nil no volume value is
 // included in the prosody element.
-// It returns the builder pointer and an error if a parameter is of an invalid type.
-func (builder *Builder) AppendProsody(rate, pitch, volume interface{}, text string) (*Builder, error) {
+// It returns an error if a parameter is of an invalid type.
+func (builder *Builder) AppendProsody(rate, pitch, volume interface{}, text string) error {
 	src := ""
 	if rate != nil {
 		rateStr, ok := rate.(prosody.Rate)
 		if !ok {
 			ratePercent, ok := rate.(int)
 			if !ok {
-				return builder, fmt.Errorf("unsupported rate type. must be either prosody.Rate or int")
+				return fmt.Errorf("unsupported rate type. must be either prosody.Rate or int")
 			}
 			src += fmt.Sprintf("rate=\"%d%%\" ", ratePercent)
 		} else {
@@ -105,7 +107,7 @@ func (builder *Builder) AppendProsody(rate, pitch, volume interface{}, text stri
 		if !ok {
 			pitchPercent, ok := pitch.(int)
 			if !ok {
-				return builder, fmt.Errorf("unsupported pitch type. must be either prosody.Pitch or int")
+				return fmt.Errorf("unsupported pitch type. must be either prosody.Pitch or int")
 			}
 			sign := ""
 			if pitchPercent > 0 {
@@ -122,7 +124,7 @@ func (builder *Builder) AppendProsody(rate, pitch, volume interface{}, text stri
 		if !ok {
 			volumeDb, ok := volume.(int)
 			if !ok {
-				return builder, fmt.Errorf("unsupported volume type. must be either prosody.Volume or int")
+				return fmt.Errorf("unsupported volume type. must be either prosody.Volume or int")
 			}
 			sign := ""
 			if volumeDb > 0 {
@@ -135,21 +137,21 @@ func (builder *Builder) AppendProsody(rate, pitch, volume interface{}, text stri
 	}
 
 	builder.buffer.WriteString(fmt.Sprintf("<prosody %s>%s</prosody>", strings.TrimSpace(src), text))
-	return builder, nil
+	return nil
 }
 
 // AppendSentence appends a sentence element to the builder's internal SSML string.
-// It returns the builder pointer and a nil error.
-func (builder *Builder) AppendSentence(text string) (*Builder, error) {
+// It returns a nil error.
+func (builder *Builder) AppendSentence(text string) error {
 	builder.buffer.WriteString(fmt.Sprintf("<s>%s</s>", text))
-	return builder, nil
+	return nil
 }
 
 // AppendSubstitution appends a substitution element to the builder's internal SSML string.
-// It returns the builder pointer and a nil error.
-func (builder *Builder) AppendSubstitution(alias, text string) (*Builder, error) {
+// It returns a nil error.
+func (builder *Builder) AppendSubstitution(alias, text string) error {
 	builder.buffer.WriteString(fmt.Sprintf("<sub alias=\"%s\">%s</sub>", alias, text))
-	return builder, nil
+	return nil
 }
 
 // Build builds the SSML string.

--- a/ssml/builder.go
+++ b/ssml/builder.go
@@ -11,11 +11,6 @@ import (
 	"github.com/mikeflynn/go-alexa/ssml/prosody"
 )
 
-/**
- * Details about the Speech Synthesis Markup Language (SSML) can be found on this page:
- * https://developer.amazon.com/public/solutions/alexa/alexa-skills-kit/docs/speech-synthesis-markup-language-ssml-reference
- */
-
 func NewBuilder() (*Builder, error) {
 	return &Builder{bytes.NewBufferString("")}, nil
 }
@@ -35,9 +30,17 @@ func (builder *Builder) AppendAudio(src string) (*Builder, error) {
 	return builder, nil
 }
 
-func (builder *Builder) AppendBreak(strength pause.Strength, duration time.Duration) (*Builder, error) {
-	durationMs := duration.Nanoseconds() / 1e6
-	builder.buffer.WriteString(fmt.Sprintf("<break strength=\"%s\" time=\"%dms\"/>", strength, durationMs))
+func (builder *Builder) AppendBreak(strengthOrDuration interface{}) (*Builder, error) {
+	strength, ok := strengthOrDuration.(pause.Strength)
+	if !ok {
+		duration, ok := strengthOrDuration.(time.Duration)
+		if !ok {
+			return builder, fmt.Errorf("unsupported parameter type. must be either pause.Strength or time.Duration")
+		}
+		builder.buffer.WriteString(fmt.Sprintf("<break time=\"%dms\"/>", duration.Nanoseconds()/1e6))
+		return builder, nil
+	}
+	builder.buffer.WriteString(fmt.Sprintf("<break strength=\"%s\"/>", strength))
 	return builder, nil
 }
 

--- a/ssml/builder.go
+++ b/ssml/builder.go
@@ -43,10 +43,10 @@ func (builder *Builder) AppendAmazonEffect(effect amazoneffect.Effect, text stri
 func (builder *Builder) AppendAudio(src string) *Builder {
 	u, err := url.Parse(src)
 	if err != nil {
-		return builder.appendError(fmt.Errorf("src failed to parse into a valid URL: %v", err))
+		return builder.appendError(fmt.Errorf("failed to parse src into a valid URL: %v", err))
 	}
 	if u.Scheme != "https" {
-		return builder.appendError(fmt.Errorf("src must be a HTTPS URL: Scheme %s not valid", u.Scheme))
+		return builder.appendError(errors.New("unsupported URL scheme type: must be https"))
 	}
 	builder.buffer.WriteString(fmt.Sprintf("<audio src=\"%s\"/>", u.String()))
 	return builder

--- a/ssml/builder_examples_test.go
+++ b/ssml/builder_examples_test.go
@@ -16,7 +16,8 @@ func ExampleNewBuilder_output() {
 	b, _ := NewBuilder()
 
 	// Print the built string.
-	fmt.Print(b.Build())
+	output, _ := b.Build()
+	fmt.Print(output)
 	// Output: <speak></speak>
 }
 
@@ -28,7 +29,8 @@ func ExampleBuilder_AppendPlainSpeech_output() {
 	b.AppendPlainSpeech("Hello World!")
 
 	// Print the built string.
-	fmt.Print(b.Build())
+	output, _ := b.Build()
+	fmt.Print(output)
 	// Output: <speak>Hello World!</speak>
 }
 
@@ -40,7 +42,8 @@ func ExampleBuilder_AppendAmazonEffect_output() {
 	b.AppendAmazonEffect(amazoneffect.Whispered, "This is whispered")
 
 	// Print the built string.
-	fmt.Print(b.Build())
+	output, _ := b.Build()
+	fmt.Print(output)
 	// Output: <speak><amazon:effect name="whispered">This is whispered</amazon:effect></speak>
 }
 
@@ -52,7 +55,8 @@ func ExampleBuilder_AppendAudio_output() {
 	b.AppendAudio("https://domain.tld/dummy.mp3")
 
 	// Print the built string.
-	fmt.Print(b.Build())
+	output, _ := b.Build()
+	fmt.Print(output)
 	// Output: <speak><audio src="https://domain.tld/dummy.mp3"/></speak>
 }
 
@@ -64,7 +68,8 @@ func ExampleBuilder_AppendBreak_Strength_output() {
 	b.AppendBreak(pause.Strong)
 
 	// Print the built string.
-	fmt.Print(b.Build())
+	output, _ := b.Build()
+	fmt.Print(output)
 	// Output: <speak><break strength="strong"/></speak>
 }
 
@@ -76,7 +81,8 @@ func ExampleBuilder_AppendBreak_Time_output() {
 	b.AppendBreak(time.Second)
 
 	// Print the built string.
-	fmt.Print(b.Build())
+	output, _ := b.Build()
+	fmt.Print(output)
 	// Output: <speak><break time="1000ms"/></speak>
 }
 
@@ -88,7 +94,8 @@ func ExampleBuilder_AppendEmphasis_output() {
 	b.AppendEmphasis(emphasis.Reduced, "reduced emphasis")
 
 	// Print the built string.
-	fmt.Print(b.Build())
+	output, _ := b.Build()
+	fmt.Print(output)
 	// Output: <speak><emphasis level="reduced">reduced emphasis</emphasis></speak>
 }
 
@@ -100,7 +107,8 @@ func ExampleBuilder_AppendParagraph_output() {
 	b.AppendParagraph("sample paragraph")
 
 	// Print the built string.
-	fmt.Print(b.Build())
+	output, _ := b.Build()
+	fmt.Print(output)
 	// Output: <speak><p>sample paragraph</p></speak>
 }
 
@@ -112,7 +120,8 @@ func ExampleBuilder_AppendProsody_Rate_output() {
 	b.AppendProsody(prosody.RateMedium, nil, nil, "this is said at a medium rate")
 
 	// Print the built string.
-	fmt.Print(b.Build())
+	output, _ := b.Build()
+	fmt.Print(output)
 	// Output: <speak><prosody rate="medium">this is said at a medium rate</prosody></speak>
 }
 
@@ -124,7 +133,8 @@ func ExampleBuilder_AppendProsody_Constants_output() {
 	b.AppendProsody(prosody.RateSlow, prosody.PitchLow, prosody.VolumeXLoud, "this is said slowly, in a low pitch, but loudly")
 
 	// Print the built string.
-	fmt.Print(b.Build())
+	output, _ := b.Build()
+	fmt.Print(output)
 	// Output: <speak><prosody rate="slow" pitch="low" volume="x-loud">this is said slowly, in a low pitch, but loudly</prosody></speak>
 }
 
@@ -133,11 +143,12 @@ func ExampleBuilder_AppendProsody_Int_output() {
 	b, _ := NewBuilder()
 
 	// Append a prosody element using ints.
-	b.AppendProsody(110, -10, 4, "this is said slightly quicker than normal (110%), in a lower pitch (-10%), loudly (+4dB)")
+	b.AppendProsody(110, -10, 4, "this is said slightly quicker than normal (110%), in a lower pitch (-10%), and loudly (+4dB)")
 
 	// Print the built string.
-	fmt.Print(b.Build())
-	// Output: <speak><prosody rate="110%" pitch="-10%" volume="+4dB">this is said slightly quicker than normal (110%), in a lower pitch (-10%), loudly (+4dB)</prosody></speak>
+	output, _ := b.Build()
+	fmt.Print(output)
+	// Output: <speak><prosody rate="110%" pitch="-10%" volume="+4dB">this is said slightly quicker than normal (110%), in a lower pitch (-10%), and loudly (+4dB)</prosody></speak>
 }
 
 func ExampleBuilder_AppendSentence_output() {
@@ -148,7 +159,8 @@ func ExampleBuilder_AppendSentence_output() {
 	b.AppendSentence("this is a sentence")
 
 	// Print the built string.
-	fmt.Print(b.Build())
+	output, _ := b.Build()
+	fmt.Print(output)
 	// Output: <speak><s>this is a sentence</s></speak>
 }
 
@@ -160,6 +172,7 @@ func ExampleBuilder_AppendSubstitution_output() {
 	b.AppendSubstitution("alias", "replacement")
 
 	// Print the built string.
-	fmt.Print(b.Build())
+	output, _ := b.Build()
+	fmt.Print(output)
 	// Output: <speak><sub alias="alias">replacement</sub></speak>
 }

--- a/ssml/builder_examples_test.go
+++ b/ssml/builder_examples_test.go
@@ -1,0 +1,165 @@
+package ssml
+
+import (
+	"fmt"
+
+	"time"
+
+	"github.com/mikeflynn/go-alexa/ssml/amazoneffect"
+	"github.com/mikeflynn/go-alexa/ssml/emphasis"
+	"github.com/mikeflynn/go-alexa/ssml/pause"
+	"github.com/mikeflynn/go-alexa/ssml/prosody"
+)
+
+func ExampleNewBuilder_output() {
+	// Create a new builder. Ignore any error.
+	b, _ := NewBuilder()
+
+	// Print the built string.
+	fmt.Print(b.Build())
+	// Output: <speak></speak>
+}
+
+func ExampleBuilder_AppendPlainSpeech_output() {
+	// Create a new builder. Ignore any error.
+	b, _ := NewBuilder()
+
+	// Append the plain speech.
+	b.AppendPlainSpeech("Hello World!")
+
+	// Print the built string.
+	fmt.Print(b.Build())
+	// Output: <speak>Hello World!</speak>
+}
+
+func ExampleBuilder_AppendAmazonEffect_output() {
+	// Create a new builder. Ignore any error.
+	b, _ := NewBuilder()
+
+	// Append some Whispered text.
+	b.AppendAmazonEffect(amazoneffect.Whispered, "This is whispered")
+
+	// Print the built string.
+	fmt.Print(b.Build())
+	// Output: <speak><amazon:effect name="whispered">This is whispered</amazon:effect></speak>
+}
+
+func ExampleBuilder_AppendAudio_output() {
+	// Create a new builder. Ignore any error.
+	b, _ := NewBuilder()
+
+	// Append an audio url.
+	b.AppendAudio("https://domain.tld/dummy.mp3")
+
+	// Print the built string.
+	fmt.Print(b.Build())
+	// Output: <speak><audio src="https://domain.tld/dummy.mp3"/></speak>
+}
+
+func ExampleBuilder_AppendBreak_Strength_output() {
+	// Create a new builder. Ignore any error.
+	b, _ := NewBuilder()
+
+	// Append a strong break.
+	b.AppendBreak(pause.Strong)
+
+	// Print the built string.
+	fmt.Print(b.Build())
+	// Output: <speak><break strength="strong"/></speak>
+}
+
+func ExampleBuilder_AppendBreak_Time_output() {
+	// Create a new builder. Ignore any error.
+	b, _ := NewBuilder()
+
+	// Append a one second break.
+	b.AppendBreak(time.Second)
+
+	// Print the built string.
+	fmt.Print(b.Build())
+	// Output: <speak><break time="1000ms"/></speak>
+}
+
+func ExampleBuilder_AppendEmphasis_output() {
+	// Create a new builder. Ignore any error.
+	b, _ := NewBuilder()
+
+	// Append some reduced emphasis text.
+	b.AppendEmphasis(emphasis.Reduced, "reduced emphasis")
+
+	// Print the built string.
+	fmt.Print(b.Build())
+	// Output: <speak><emphasis level="reduced">reduced emphasis</emphasis></speak>
+}
+
+func ExampleBuilder_AppendParagraph_output() {
+	// Create a new builder. Ignore any error.
+	b, _ := NewBuilder()
+
+	// Append a paragraph.
+	b.AppendParagraph("sample paragraph")
+
+	// Print the built string.
+	fmt.Print(b.Build())
+	// Output: <speak><p>sample paragraph</p></speak>
+}
+
+func ExampleBuilder_AppendProsody_Rate_output() {
+	// Create a new builder. Ignore any error.
+	b, _ := NewBuilder()
+
+	// Append a prosody element which just modified the rate.
+	b.AppendProsody(prosody.RateMedium, nil, nil, "this is said at a medium rate")
+
+	// Print the built string.
+	fmt.Print(b.Build())
+	// Output: <speak><prosody rate="medium">this is said at a medium rate</prosody></speak>
+}
+
+func ExampleBuilder_AppendProsody_Constants_output() {
+	// Create a new builder. Ignore any error.
+	b, _ := NewBuilder()
+
+	// Append a prosody element using pre-defined constants.
+	b.AppendProsody(prosody.RateSlow, prosody.PitchLow, prosody.VolumeXLoud, "this is said slowly, in a low pitch, but loudly")
+
+	// Print the built string.
+	fmt.Print(b.Build())
+	// Output: <speak><prosody rate="slow" pitch="low" volume="x-loud">this is said slowly, in a low pitch, but loudly</prosody></speak>
+}
+
+func ExampleBuilder_AppendProsody_Int_output() {
+	// Create a new builder. Ignore any error.
+	b, _ := NewBuilder()
+
+	// Append a prosody element using ints.
+	b.AppendProsody(110, -10, 4, "this is said slightly quicker than normal (110%), in a lower pitch (-10%), loudly (+4dB)")
+
+	// Print the built string.
+	fmt.Print(b.Build())
+	// Output: <speak><prosody rate="110%" pitch="-10%" volume="+4dB">this is said slightly quicker than normal (110%), in a lower pitch (-10%), loudly (+4dB)</prosody></speak>
+}
+
+func ExampleBuilder_AppendSentence_output() {
+	// Create a new builder. Ignore any error.
+	b, _ := NewBuilder()
+
+	// Append a sentence.
+	b.AppendSentence("this is a sentence")
+
+	// Print the built string.
+	fmt.Print(b.Build())
+	// Output: <speak><s>this is a sentence</s></speak>
+}
+
+func ExampleBuilder_AppendSubstitution_output() {
+	// Create a new builder. Ignore any error.
+	b, _ := NewBuilder()
+
+	// Append a substation element.
+	b.AppendSubstitution("alias", "replacement")
+
+	// Print the built string.
+	fmt.Print(b.Build())
+	// Output: <speak><sub alias="alias">replacement</sub></speak>
+}

--- a/ssml/builder_test.go
+++ b/ssml/builder_test.go
@@ -2,6 +2,7 @@ package ssml
 
 import (
 	"testing"
+
 	"time"
 
 	"github.com/mikeflynn/go-alexa/ssml/amazoneffect"
@@ -84,65 +85,84 @@ func TestBuilder_AppendAudio(t *testing.T) {
 func TestBuilder_AppendBreak(t *testing.T) {
 	tests := []struct {
 		name     string
-		strength pause.Strength
-		duration time.Duration
+		param    interface{}
+		err      bool
 		expected string
 	}{
 		{
 			name:     "default",
-			strength: pause.Default,
-			duration: time.Second,
-			expected: `<speak><break strength="medium" time="1000ms"/><break strength="medium" time="1000ms"/></speak>`,
+			param:    pause.Default,
+			err:      false,
+			expected: `<speak><break strength="medium"/><break strength="medium"/></speak>`,
 		},
 		{
 			name:     "none",
-			strength: pause.None,
-			duration: time.Second / 2,
-			expected: `<speak><break strength="none" time="500ms"/><break strength="none" time="500ms"/></speak>`,
+			param:    pause.None,
+			err:      false,
+			expected: `<speak><break strength="none"/><break strength="none"/></speak>`,
 		},
 		{
 			name:     "x-weak",
-			strength: pause.XWeak,
-			duration: time.Second * 2,
-			expected: `<speak><break strength="x-weak" time="2000ms"/><break strength="x-weak" time="2000ms"/></speak>`,
+			param:    pause.XWeak,
+			err:      false,
+			expected: `<speak><break strength="x-weak"/><break strength="x-weak"/></speak>`,
 		},
 		{
 			name:     "weak",
-			strength: pause.Weak,
-			duration: time.Second * 3,
-			expected: `<speak><break strength="weak" time="3000ms"/><break strength="weak" time="3000ms"/></speak>`,
+			param:    pause.Weak,
+			err:      false,
+			expected: `<speak><break strength="weak"/><break strength="weak"/></speak>`,
 		},
 		{
 			name:     "medium",
-			strength: pause.Medium,
-			duration: time.Second * 4,
-			expected: `<speak><break strength="medium" time="4000ms"/><break strength="medium" time="4000ms"/></speak>`,
+			param:    pause.Medium,
+			err:      false,
+			expected: `<speak><break strength="medium"/><break strength="medium"/></speak>`,
 		},
 		{
 			name:     "strong",
-			strength: pause.Strong,
-			duration: time.Second * 5,
-			expected: `<speak><break strength="strong" time="5000ms"/><break strength="strong" time="5000ms"/></speak>`,
+			param:    pause.Strong,
+			err:      false,
+			expected: `<speak><break strength="strong"/><break strength="strong"/></speak>`,
 		},
 		{
 			name:     "x-strong",
-			strength: pause.XStrong,
-			duration: time.Second * 6,
-			expected: `<speak><break strength="x-strong" time="6000ms"/><break strength="x-strong" time="6000ms"/></speak>`,
+			param:    pause.XStrong,
+			err:      false,
+			expected: `<speak><break strength="x-strong"/><break strength="x-strong"/></speak>`,
 		},
 		{
 			name:     "custom",
-			strength: pause.Strength("custom"),
-			duration: time.Second * 7,
-			expected: `<speak><break strength="custom" time="7000ms"/><break strength="custom" time="7000ms"/></speak>`,
+			param:    pause.Strength("custom"),
+			err:      false,
+			expected: `<speak><break strength="custom"/><break strength="custom"/></speak>`,
+		},
+		{
+			name:     "time",
+			param:    time.Second,
+			err:      false,
+			expected: `<speak><break time="1000ms"/><break time="1000ms"/></speak>`,
+		},
+		{
+			name:     "invalidType",
+			param:    4,
+			err:      true,
+			expected: `<speak></speak>`,
 		},
 	}
 
 	for _, test := range tests {
 		b, _ := NewBuilder()
 
-		b.AppendBreak(test.strength, test.duration)
-		b.AppendBreak(test.strength, test.duration)
+		_, err := b.AppendBreak(test.param)
+		if (err != nil) != test.err {
+			t.Errorf("%s: error mismatch: expected %t, got %v", test.name, test.err, err)
+		}
+
+		_, err = b.AppendBreak(test.param)
+		if (err != nil) != test.err {
+			t.Errorf("%s: error mismatch: expected %t, got %v", test.name, test.err, err)
+		}
 
 		actual := b.Build()
 		if actual != test.expected {

--- a/ssml/builder_test.go
+++ b/ssml/builder_test.go
@@ -268,9 +268,10 @@ func TestBuilder_AppendParagraph(t *testing.T) {
 func TestBuilder_AppendProsody(t *testing.T) {
 	tests := []struct {
 		name     string
-		rate     prosody.Rate
-		pitch    prosody.Pitch
-		volume   prosody.Volume
+		rate     interface{}
+		pitch    interface{}
+		volume   interface{}
+		err      bool
 		expected string
 	}{
 		{
@@ -278,6 +279,7 @@ func TestBuilder_AppendProsody(t *testing.T) {
 			rate:     prosody.RateXSlow,
 			pitch:    prosody.PitchXLow,
 			volume:   prosody.VolumeSilent,
+			err:      false,
 			expected: `<speak><prosody rate="x-slow" pitch="x-low" volume="silent">text1</prosody><prosody rate="x-slow" pitch="x-low" volume="silent">text2</prosody></speak>`,
 		},
 		{
@@ -285,6 +287,7 @@ func TestBuilder_AppendProsody(t *testing.T) {
 			rate:     prosody.RateSlow,
 			pitch:    prosody.PitchLow,
 			volume:   prosody.VolumeXSoft,
+			err:      false,
 			expected: `<speak><prosody rate="slow" pitch="low" volume="x-soft">text1</prosody><prosody rate="slow" pitch="low" volume="x-soft">text2</prosody></speak>`,
 		},
 		{
@@ -292,6 +295,7 @@ func TestBuilder_AppendProsody(t *testing.T) {
 			rate:     prosody.RateMedium,
 			pitch:    prosody.PitchMedium,
 			volume:   prosody.VolumeSoft,
+			err:      false,
 			expected: `<speak><prosody rate="medium" pitch="medium" volume="soft">text1</prosody><prosody rate="medium" pitch="medium" volume="soft">text2</prosody></speak>`,
 		},
 		{
@@ -299,6 +303,7 @@ func TestBuilder_AppendProsody(t *testing.T) {
 			rate:     prosody.RateFast,
 			pitch:    prosody.PitchHigh,
 			volume:   prosody.VolumeMedium,
+			err:      false,
 			expected: `<speak><prosody rate="fast" pitch="high" volume="medium">text1</prosody><prosody rate="fast" pitch="high" volume="medium">text2</prosody></speak>`,
 		},
 		{
@@ -306,6 +311,7 @@ func TestBuilder_AppendProsody(t *testing.T) {
 			rate:     prosody.RateXFast,
 			pitch:    prosody.PitchXHigh,
 			volume:   prosody.VolumeLoud,
+			err:      false,
 			expected: `<speak><prosody rate="x-fast" pitch="x-high" volume="loud">text1</prosody><prosody rate="x-fast" pitch="x-high" volume="loud">text2</prosody></speak>`,
 		},
 		{
@@ -313,6 +319,7 @@ func TestBuilder_AppendProsody(t *testing.T) {
 			rate:     prosody.RateXFast,
 			pitch:    prosody.PitchXHigh,
 			volume:   prosody.VolumeXLoud,
+			err:      false,
 			expected: `<speak><prosody rate="x-fast" pitch="x-high" volume="x-loud">text1</prosody><prosody rate="x-fast" pitch="x-high" volume="x-loud">text2</prosody></speak>`,
 		},
 		{
@@ -320,15 +327,119 @@ func TestBuilder_AppendProsody(t *testing.T) {
 			rate:     prosody.Rate("custom rate"),
 			pitch:    prosody.Pitch("custom pitch"),
 			volume:   prosody.Volume("custom volume"),
+			err:      false,
 			expected: `<speak><prosody rate="custom rate" pitch="custom pitch" volume="custom volume">text1</prosody><prosody rate="custom rate" pitch="custom pitch" volume="custom volume">text2</prosody></speak>`,
+		},
+		{
+			name:     "onlyRate",
+			rate:     prosody.RateXSlow,
+			pitch:    nil,
+			volume:   nil,
+			err:      false,
+			expected: `<speak><prosody rate="x-slow">text1</prosody><prosody rate="x-slow">text2</prosody></speak>`,
+		},
+		{
+			name:     "onlyPitch",
+			rate:     nil,
+			pitch:    prosody.PitchXLow,
+			volume:   nil,
+			err:      false,
+			expected: `<speak><prosody pitch="x-low">text1</prosody><prosody pitch="x-low">text2</prosody></speak>`,
+		},
+		{
+			name:     "onlyVolume",
+			rate:     nil,
+			pitch:    nil,
+			volume:   prosody.VolumeSilent,
+			err:      false,
+			expected: `<speak><prosody volume="silent">text1</prosody><prosody volume="silent">text2</prosody></speak>`,
+		},
+		{
+			name:     "percentageRate",
+			rate:     110,
+			pitch:    nil,
+			volume:   nil,
+			err:      false,
+			expected: `<speak><prosody rate="110%">text1</prosody><prosody rate="110%">text2</prosody></speak>`,
+		},
+		{
+			name:     "positivePercentagePitch",
+			rate:     nil,
+			pitch:    10,
+			volume:   nil,
+			err:      false,
+			expected: `<speak><prosody pitch="+10%">text1</prosody><prosody pitch="+10%">text2</prosody></speak>`,
+		},
+		{
+			name:     "negativePercentagePitch",
+			rate:     nil,
+			pitch:    -10,
+			volume:   nil,
+			err:      false,
+			expected: `<speak><prosody pitch="-10%">text1</prosody><prosody pitch="-10%">text2</prosody></speak>`,
+		},
+		{
+			name:     "positiveDbVolume",
+			rate:     nil,
+			pitch:    nil,
+			volume:   4,
+			err:      false,
+			expected: `<speak><prosody volume="+4dB">text1</prosody><prosody volume="+4dB">text2</prosody></speak>`,
+		},
+		{
+			name:     "negativeDbVolume",
+			rate:     nil,
+			pitch:    nil,
+			volume:   -4,
+			err:      false,
+			expected: `<speak><prosody volume="-4dB">text1</prosody><prosody volume="-4dB">text2</prosody></speak>`,
+		},
+		{
+			name:     "allNil",
+			rate:     nil,
+			pitch:    nil,
+			volume:   nil,
+			err:      false,
+			expected: `<speak><prosody >text1</prosody><prosody >text2</prosody></speak>`,
+		},
+		{
+			name:     "invalidRateType",
+			rate:     true,
+			pitch:    nil,
+			volume:   nil,
+			err:      true,
+			expected: `<speak></speak>`,
+		},
+		{
+			name:     "invalidPitchType",
+			rate:     nil,
+			pitch:    true,
+			volume:   nil,
+			err:      true,
+			expected: `<speak></speak>`,
+		},
+		{
+			name:     "invalidVolumeType",
+			rate:     nil,
+			pitch:    nil,
+			volume:   true,
+			err:      true,
+			expected: `<speak></speak>`,
 		},
 	}
 
 	for _, test := range tests {
 		b, _ := NewBuilder()
 
-		b.AppendProsody(test.rate, test.pitch, test.volume, "text1")
-		b.AppendProsody(test.rate, test.pitch, test.volume, "text2")
+		_, err := b.AppendProsody(test.rate, test.pitch, test.volume, "text1")
+		if (err != nil) != test.err {
+			t.Errorf("%s: error mismatch: expected %t, got %v", test.name, test.err, err)
+		}
+
+		_, err = b.AppendProsody(test.rate, test.pitch, test.volume, "text2")
+		if (err != nil) != test.err {
+			t.Errorf("%s: error mismatch: expected %t, got %v", test.name, test.err, err)
+		}
 
 		actual := b.Build()
 		if actual != test.expected {

--- a/ssml/builder_test.go
+++ b/ssml/builder_test.go
@@ -99,12 +99,12 @@ func TestBuilder_AppendAudio(t *testing.T) {
 	for _, test := range tests {
 		b, _ := NewBuilder()
 
-		_, err := b.AppendAudio(test.src)
+		err := b.AppendAudio(test.src)
 		if (err != nil) != test.err {
 			t.Errorf("%s: error mismatch: expected %t, got %v", test.name, test.err, err)
 		}
 
-		_, err = b.AppendAudio(test.src)
+		err = b.AppendAudio(test.src)
 		if (err != nil) != test.err {
 			t.Errorf("%s: error mismatch: expected %t, got %v", test.name, test.err, err)
 		}
@@ -188,12 +188,12 @@ func TestBuilder_AppendBreak(t *testing.T) {
 	for _, test := range tests {
 		b, _ := NewBuilder()
 
-		_, err := b.AppendBreak(test.param)
+		err := b.AppendBreak(test.param)
 		if (err != nil) != test.err {
 			t.Errorf("%s: error mismatch: expected %t, got %v", test.name, test.err, err)
 		}
 
-		_, err = b.AppendBreak(test.param)
+		err = b.AppendBreak(test.param)
 		if (err != nil) != test.err {
 			t.Errorf("%s: error mismatch: expected %t, got %v", test.name, test.err, err)
 		}
@@ -431,12 +431,12 @@ func TestBuilder_AppendProsody(t *testing.T) {
 	for _, test := range tests {
 		b, _ := NewBuilder()
 
-		_, err := b.AppendProsody(test.rate, test.pitch, test.volume, "text1")
+		err := b.AppendProsody(test.rate, test.pitch, test.volume, "text1")
 		if (err != nil) != test.err {
 			t.Errorf("%s: error mismatch: expected %t, got %v", test.name, test.err, err)
 		}
 
-		_, err = b.AppendProsody(test.rate, test.pitch, test.volume, "text2")
+		err = b.AppendProsody(test.rate, test.pitch, test.volume, "text2")
 		if (err != nil) != test.err {
 			t.Errorf("%s: error mismatch: expected %t, got %v", test.name, test.err, err)
 		}

--- a/ssml/builder_test.go
+++ b/ssml/builder_test.go
@@ -70,15 +70,49 @@ func TestBuilder_AppendAmazonEffect(t *testing.T) {
 }
 
 func TestBuilder_AppendAudio(t *testing.T) {
-	b, _ := NewBuilder()
+	tests := []struct {
+		name     string
+		src      string
+		err      bool
+		expected string
+	}{
+		{
+			name:     "happyPath",
+			src:      "https://domain.tld",
+			err:      false,
+			expected: `<speak><audio src="https://domain.tld"/><audio src="https://domain.tld"/></speak>`,
+		},
+		{
+			name:     "nonHTTPSUrl",
+			src:      "http://domain.tld",
+			err:      true,
+			expected: `<speak></speak>`,
+		},
+		{
+			name:     "badUrl",
+			src:      "notarealurl",
+			err:      true,
+			expected: `<speak></speak>`,
+		},
+	}
 
-	b.AppendAudio("source1")
-	b.AppendAudio("source2")
+	for _, test := range tests {
+		b, _ := NewBuilder()
 
-	actual := b.Build()
-	expected := `<speak><audio src="source1"/><audio src="source2"/></speak>`
-	if actual != expected {
-		t.Errorf("output mismatch: expected %s, got %s", expected, actual)
+		_, err := b.AppendAudio(test.src)
+		if (err != nil) != test.err {
+			t.Errorf("%s: error mismatch: expected %t, got %v", test.name, test.err, err)
+		}
+
+		_, err = b.AppendAudio(test.src)
+		if (err != nil) != test.err {
+			t.Errorf("%s: error mismatch: expected %t, got %v", test.name, test.err, err)
+		}
+
+		actual := b.Build()
+		if actual != test.expected {
+			t.Errorf("%s: output mismatch: expected %s, got %s", test.name, test.expected, actual)
+		}
 	}
 }
 

--- a/ssml/types.go
+++ b/ssml/types.go
@@ -2,8 +2,13 @@
 // Details about SSML can be found on this page: https://developer.amazon.com/public/solutions/alexa/alexa-skills-kit/docs/speech-synthesis-markup-language-ssml-reference
 package ssml
 
-import "bytes"
+import (
+	"bytes"
+	"sync"
+)
 
 type Builder struct {
 	buffer *bytes.Buffer
+	lock   sync.RWMutex
+	errs   []error
 }

--- a/ssml/types.go
+++ b/ssml/types.go
@@ -2,6 +2,6 @@ package ssml
 
 import "bytes"
 
-type builder struct {
+type Builder struct {
 	buffer *bytes.Buffer
 }

--- a/ssml/types.go
+++ b/ssml/types.go
@@ -1,3 +1,5 @@
+// package ssml provides a Speech Synthesis Markup Language (SSML) string builder for use in Alexa skills.
+// Details about SSML can be found on this page: https://developer.amazon.com/public/solutions/alexa/alexa-skills-kit/docs/speech-synthesis-markup-language-ssml-reference
 package ssml
 
 import "bytes"


### PR DESCRIPTION
# Overview

- Added `Deprecated` notice to `SSMLTextBuilder` type & functions in `skillserver` package
- Added flexible parameters & parameter validation to a few `Append` functions
- Added documentation
- Added examples

# Details

- Added `Deprecated` notice to SSML builder type & funcs in skillserver package
- Added flexible parameters & parameter validation to `AppendBreak`
 - Now takes either a `pause.Strength` param or a `time.Duration`
- Added parameter validation to `AppendAudio`
 - Now checks to make sure it's a valid HTTPS url
- Added flexible parameters & parameter validation to `AppendProsody`
 - Now takes either `prosody.*` constants or `int`s
 - Also makes all parameters optional (with `nil`)
- Added documentation to the package and all functions
 - Exported the `Builder` type so all `Append` functions appear in the generated documentation
- Added examples for all functions
- Append functions now only return an error. The builder doesn't need to be returned since a pointer receiver is being used

# Testing

- 100% unit tests of `ssml` package pass
- 100% example tests of `ssml` package pass

# TODO

- Support for more SSML features