### PR TITLE
Add a cache for alexa certificate to avoid redundant traffic

### DIFF
--- a/skillserver/skillserver_test.go
+++ b/skillserver/skillserver_test.go
@@ -1,0 +1,21 @@
+package skillserver
+
+import (
+	"testing"
+	"crypto/x509"
+	"time"
+)
+
+func TestIsCertExpired(t *testing.T) {
+	cert := &x509.Certificate{
+		NotBefore: time.Date(2017, time.January, 10, 0, 0, 0, 0, time.UTC),
+		NotAfter: time.Date(2017, time.January, 12, 0, 0, 0, 0, time.UTC),
+	}
+
+	now := time.Date(2017, time.January, 14, 0, 0, 0, 0, time.UTC)
+
+	if !isCertExpired(cert, now) {
+		t.Error("Cert should have been expired")
+	}
+}
+


### PR DESCRIPTION
Current implementation will trigger an HTTP call to retrieve a certificate for signature verification. 

Proposed change introduces optimization, which will allow to store certificate in-memory until it expires. In current implementation up to 5 certificates could be stored.