### PR TITLE
Adding applicationID to the context property

### DIFF
--- a/skillserver/echo.go
+++ b/skillserver/echo.go
@@ -17,7 +17,8 @@ func (this *EchoRequest) VerifyTimestamp() bool {
 }
 
 func (this *EchoRequest) VerifyAppID(myAppID string) bool {
-	if this.Session.Application.ApplicationID == myAppID {
+	if this.Session.Application.ApplicationID == myAppID ||
+		this.Context.System.Application.ApplicationID == myAppID {
 		return true
 	}
 
@@ -191,6 +192,9 @@ type EchoContext struct {
 		Device struct {
 			DeviceId string `json:"deviceId,omitempty"`
 		} `json:"device,omitempty"`
+		Application struct {
+			ApplicationID string `json:"applicationId:omitempty"`
+		} `json:"application:omitempty"`
 	} `json:"System,omitempty"`
 }
 


### PR DESCRIPTION
This allows the server to check the context for the application ID to be verified
during AudioPlayback requests instead of automatically returning a 400 response
when the session property is not available.

Fixes #30