### PR TITLE
Added the applicationID to the context object

### DIFF
--- a/skillserver/echo.go
+++ b/skillserver/echo.go
@@ -17,7 +17,8 @@ func (this *EchoRequest) VerifyTimestamp() bool {
 }
 
 func (this *EchoRequest) VerifyAppID(myAppID string) bool {
-	if this.Session.Application.ApplicationID == myAppID {
+	if this.Session.Application.ApplicationID == myAppID ||
+		this.Context.System.Application.ApplicationID == myAppID {
 		return true
 	}
 
@@ -191,6 +192,9 @@ type EchoContext struct {
 		Device struct {
 			DeviceId string `json:"deviceId,omitempty"`
 		} `json:"device,omitempty"`
+		Application struct {
+			ApplicationID string `json:"applicationId,omitempty"`
+		} `json:"application,omitempty"`
 	} `json:"System,omitempty"`
 }
 

--- a/skillserver/skillserver.go
+++ b/skillserver/skillserver.go
@@ -24,11 +24,12 @@ import (
 )
 
 type EchoApplication struct {
-	AppID          string
-	Handler        func(http.ResponseWriter, *http.Request)
-	OnLaunch       func(*EchoRequest, *EchoResponse)
-	OnIntent       func(*EchoRequest, *EchoResponse)
-	OnSessionEnded func(*EchoRequest, *EchoResponse)
+	AppID              string
+	Handler            func(http.ResponseWriter, *http.Request)
+	OnLaunch           func(*EchoRequest, *EchoResponse)
+	OnIntent           func(*EchoRequest, *EchoResponse)
+	OnSessionEnded     func(*EchoRequest, *EchoResponse)
+	OnAudioPlayerState func(*EchoRequest, *EchoResponse)
 }
 
 type StdApplication struct {
@@ -81,6 +82,10 @@ func Init(apps map[string]interface{}, router *mux.Router) {
 				} else if echoReq.GetRequestType() == "SessionEndedRequest" {
 					if app.OnSessionEnded != nil {
 						app.OnSessionEnded(echoReq, echoResp)
+					}
+				} else if strings.HasPrefix(echoReq.GetRequestType(), "AudioPlayer.") {
+					if app.OnAudioPlayerState != nil {
+						app.OnAudioPlayerState(echoReq, echoResp)
 					}
 				} else {
 					http.Error(w, "Invalid request.", http.StatusBadRequest)


### PR DESCRIPTION
This allows the server to check the context for the application ID to be verified
during AudioPlayback requests instead of automatically returning a 400 response
when the session property is not available.

Also added a new OnAudioPlayerState handler to handle requests caused by playback state changes.

Fixes #30