### PR TITLE
[Refactor] Add ApiAccessToken to request struct

### DIFF
--- a/customskill/request/types.go
+++ b/customskill/request/types.go
@@ -47,10 +47,11 @@ type Context struct {
 }
 
 type System struct {
-	Application Application `json:"application"`
-	User        User        `json:"user"`
-	Device      Device      `json:"device"`
-	ApiEndpoint string      `json:"apiEndpoint"`
+	Application    Application `json:"application"`
+	User           User        `json:"user"`
+	Device         Device      `json:"device"`
+	ApiEndpoint    string      `json:"apiEndpoint"`
+	ApiAccessToken string      `json:"apiAccessToken"`
 }
 
 type Application struct {


### PR DESCRIPTION
# Notes

- Type: feature
- Issue: #22

Simple change. `ApiAccessToken` is missing from the `System` request struct. This code change adds it.