### PR TITLE
[Refactor] Add a default http handler to Skill

### DIFF
--- a/customskill/examples/http.go
+++ b/customskill/examples/http.go
@@ -1,9 +1,6 @@
 package main
 
 import (
-	"bytes"
-	"io"
-	"log"
 	"net/http"
 
 	"github.com/mikeflynn/go-alexa/customskill"
@@ -15,24 +12,12 @@ var (
 	s customskill.Skill
 )
 
-func handler(w http.ResponseWriter, r *http.Request) {
-	buf := bytes.NewBuffer(nil)
-	if _, err := io.Copy(buf, r.Body); err != nil {
-		log.Panicf("failed to copy request body to buffer: %v", err)
-	}
-	defer r.Body.Close()
-	if err := s.Handle(w, buf.Bytes()); err != nil {
-		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
-		log.Printf("Got an error: %v", err)
-	}
-}
-
 func main() {
 	s = customskill.Skill{
 		OnLaunch: onLaunch,
 	}
 
-	http.HandleFunc("/", handler)
+	http.HandleFunc("/", s.DefaultHTTPHandler)
 	http.ListenAndServe(":8080", nil)
 }
 


### PR DESCRIPTION
# Notes

- Type: feature
- Issue: #22

To make life easier for skill developers I have added a default HTTP handler to the `customskill` package in this code change. See the example in `customskill/examples/http.go`. Tests have 100% coverage.
  
  