### PR TITLE
[Refactor] import cleanup

### DIFF
--- a/customskill/request/request.go
+++ b/customskill/request/request.go
@@ -2,8 +2,7 @@ package request
 
 import (
 	"encoding/json"
-
-	"github.com/pkg/errors"
+	"errors"
 )
 
 var jsonUnmarshal = json.Unmarshal // Used to enable unit testing
@@ -16,29 +15,29 @@ func BootstrapFromJSON(data []byte) (*Metadata, interface{}, error) {
 	var efu envelope
 
 	if err := jsonUnmarshal(data, &efu); err != nil {
-		return nil, nil, errors.Errorf("failed to unmarshal elements common to all request envelopes: %v", err)
+		return nil, nil, errors.New("failed to unmarshal elements common to all request envelopes: " + err.Error())
 	}
 
 	switch efu.Request.Type {
 	case "LaunchRequest":
 		var env launchRequestEnvelope
 		if err := jsonUnmarshal(data, &env); err != nil {
-			return nil, nil, errors.Errorf("failed to unmarshal launch request envelope: %v", err)
+			return nil, nil, errors.New("failed to unmarshal launch request envelope: " + err.Error())
 		}
 		return &efu.Metadata, &env.Request, nil
 	case "IntentRequest":
 		var env intentRequestEnvelope
 		if err := jsonUnmarshal(data, &env); err != nil {
-			return nil, nil, errors.Errorf("failed to unmarshal intent request envelope: %v", err)
+			return nil, nil, errors.New("failed to unmarshal intent request envelope: " + err.Error())
 		}
 		return &efu.Metadata, &env.Request, nil
 	case "SessionEndedRequest":
 		var env sessionEndedRequestEnvelope
 		if err := jsonUnmarshal(data, &env); err != nil {
-			return nil, nil, errors.Errorf("failed to unmarshal session ended request envelope: %v", err)
+			return nil, nil, errors.New("failed to unmarshal session ended request envelope: " + err.Error())
 		}
 		return &efu.Metadata, &env.Request, nil
 	default:
-		return nil, nil, errors.Errorf("request type %s not supported", efu.Request.Type)
+		return nil, nil, errors.New("request type " + efu.Request.Type + " not supported")
 	}
 }

--- a/customskill/request/request_test.go
+++ b/customskill/request/request_test.go
@@ -2,11 +2,10 @@ package request
 
 import (
 	"encoding/json"
+	"errors"
 	"reflect"
 	"strings"
 	"testing"
-
-	"github.com/pkg/errors"
 )
 
 func TestRequest_BootstrapFromJSON(t *testing.T) {

--- a/customskill/response/envelope.go
+++ b/customskill/response/envelope.go
@@ -1,7 +1,5 @@
 package response
 
-import "fmt"
-
 func NewEnvelope(resp *Response, session map[string]interface{}) *envelope {
 	return &envelope{
 		Version:           "1.0",
@@ -13,7 +11,7 @@ func NewEnvelope(resp *Response, session map[string]interface{}) *envelope {
 func (e *envelope) String() string {
 	b, err := jsonMarshal(e)
 	if err != nil {
-		return fmt.Sprintf("failed to marshal JSON: %v", err)
+		return "failed to marshal envelope to JSON: " + err.Error()
 	}
 
 	return string(b)

--- a/customskill/response/envelope_test.go
+++ b/customskill/response/envelope_test.go
@@ -35,7 +35,7 @@ func TestEnvelope_String_Failure(t *testing.T) {
 		return nil, errors.New("dummy error")
 	}
 	got := NewEnvelope(nil, nil).String()
-	want := "failed to marshal JSON: dummy error"
+	want := "failed to marshal envelope to JSON: dummy error"
 
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("request mismatch:\n\tgot:    %#v\n\twanted: %#v", got, want)

--- a/customskill/response/response.go
+++ b/customskill/response/response.go
@@ -1,9 +1,5 @@
 package response
 
-import (
-	"fmt"
-)
-
 func New() *Response {
 	return &Response{
 		ShouldEndSession: Bool(true),
@@ -98,7 +94,7 @@ func (r *Response) SetEndSession(flag *bool) *Response {
 func (r *Response) String() string {
 	b, err := jsonMarshal(r)
 	if err != nil {
-		return fmt.Sprintf("failed to marshal JSON: %v", err)
+		return "failed to marshal response to JSON: " + err.Error()
 	}
 
 	return string(b)

--- a/customskill/response/response_test.go
+++ b/customskill/response/response_test.go
@@ -232,7 +232,7 @@ func TestResponse_String_Failure(t *testing.T) {
 		return nil, errors.New("dummy error")
 	}
 	got := New().String()
-	want := "failed to marshal JSON: dummy error"
+	want := "failed to marshal response to JSON: dummy error"
 
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("request mismatch:\n\tgot:    %#v\n\twanted: %#v", got, want)

--- a/customskill/skill.go
+++ b/customskill/skill.go
@@ -2,11 +2,14 @@ package customskill
 
 import (
 	"encoding/json"
+	"errors"
 	"io"
+	"reflect"
+	"strconv"
+	"strings"
 
 	"github.com/mikeflynn/go-alexa/customskill/request"
 	"github.com/mikeflynn/go-alexa/customskill/response"
-	"github.com/pkg/errors"
 )
 
 var (
@@ -24,56 +27,56 @@ func (s *Skill) Handle(w io.Writer, b []byte) error {
 
 	m, e, err := requestBootstrapFromJSON(b)
 	if err != nil {
-		return errors.Errorf("failed to bootstrap request from JSON payload: %v", err)
+		return errors.New("failed to bootstrap request from JSON payload: " + err.Error())
 	}
 
 	if !s.applicationIDIsValid(m.Session.Application.ApplicationID) {
-		return errors.Errorf("application ID %s is not in the list of valid application IDs: %v", m.Session.Application.ApplicationID, s.ValidApplicationIDs)
+		return errors.New("application ID " + m.Session.Application.ApplicationID + " is not in the list of valid application IDs: " + strings.Join(s.ValidApplicationIDs, ","))
 	}
 
 	switch e.(type) {
 	case *request.LaunchRequest:
 		if s.OnLaunch == nil {
-			return errors.Errorf("no OnLaunch handler defined")
+			return errors.New("no OnLaunch handler defined")
 		}
 		lr := e.(*request.LaunchRequest)
 		resp, sess, err = s.OnLaunch(lr)
 		if err != nil {
-			return errors.Errorf("OnLaunch handler failed: %v", err)
+			return errors.New("OnLaunch handler failed: " + err.Error())
 		}
 	case *request.IntentRequest:
 		if s.OnIntent == nil {
-			return errors.Errorf("no OnIntent handler defined")
+			return errors.New("no OnIntent handler defined")
 		}
 		ir := e.(*request.IntentRequest)
 		resp, sess, err = s.OnIntent(ir, &m.Session)
 		if err != nil {
-			return errors.Errorf("OnIntent handler failed: %v", err)
+			return errors.New("OnIntent handler failed: " + err.Error())
 		}
 	case *request.SessionEndedRequest:
 		if s.OnSessionEnded == nil {
-			return errors.Errorf("no OnSessionEnded handler defined")
+			return errors.New("no OnSessionEnded handler defined")
 		}
 		ser := e.(*request.SessionEndedRequest)
 		if err = s.OnSessionEnded(ser); err != nil {
-			return errors.Errorf("OnSessionEnded handler failed: %v", err)
+			return errors.New("OnSessionEnded handler failed: " + err.Error())
 		}
 		// A skill cannot return a response to SessionEndedRequest.
 		return nil
 	default:
-		return errors.Errorf("unsupported request type: %T", e)
+		return errors.New("unsupported request type: " + getType(e))
 	}
 
 	jsonB, err := jsonMarshal(response.NewEnvelope(resp, sess))
 	if err != nil {
-		return errors.Errorf("failed to marshal response: %v", err)
+		return errors.New("failed to marshal response: " + err.Error())
 	}
 	n, err := w.Write(jsonB)
 	if err != nil {
-		return errors.Errorf("failed to write response: %v", err)
+		return errors.New("failed to write response: " + err.Error())
 	}
 	if n != len(jsonB) {
-		return errors.Errorf("failed to completely write response: %d of %d bytes written", n, len(jsonB))
+		return errors.New("failed to completely write response: " + strconv.Itoa(n) + " of " + strconv.Itoa(len(jsonB)) + " bytes written")
 	}
 	return nil
 }
@@ -85,4 +88,12 @@ func (s *Skill) applicationIDIsValid(appID string) bool {
 		}
 	}
 	return false
+}
+
+func getType(i interface{}) string {
+	t := reflect.TypeOf(i)
+	if t == nil {
+		return "<nil>"
+	}
+	return t.String()
 }

--- a/customskill/skill_test.go
+++ b/customskill/skill_test.go
@@ -134,7 +134,7 @@ func handleTests(t testingiface) {
 			partialErrorMessage: strPointer("failed to bootstrap request from JSON payload"),
 		},
 		{
-			name: "unsupported-request-type-returns-error",
+			name: "nil-request-type-returns-error",
 			skill: &Skill{
 				ValidApplicationIDs: []string{"testApplicationId"},
 			},
@@ -148,7 +148,23 @@ func handleTests(t testingiface) {
 				}, nil, nil
 			},
 			partialErrorMessage: strPointer("unsupported request type: <nil>"),
+		}, {
+			name: "unsupported-request-type-returns-error",
+			skill: &Skill{
+				ValidApplicationIDs: []string{"testApplicationId"},
+			},
+			requestBootstrapFromJSON: func(data []byte) (*request.Metadata, interface{}, error) {
+				return &request.Metadata{
+					Session: request.Session{
+						Application: request.Application{
+							ApplicationID: "testApplicationId",
+						},
+					},
+				}, 0, nil
+			},
+			partialErrorMessage: strPointer("unsupported request type: int"),
 		},
+
 		{
 			name:  "invalid-application-id-returns-error",
 			skill: &Skill{},

--- a/customskill/skill_test.go
+++ b/customskill/skill_test.go
@@ -14,7 +14,16 @@ import (
 )
 
 func TestSkill_Handle(t *testing.T) {
+	handleTests(t)
+}
 
+func BenchmarkSkill_Handle(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		handleTests(b)
+	}
+}
+
+func handleTests(t testingiface) {
 	var tests = []struct {
 		name                     string
 		skill                    *Skill
@@ -348,6 +357,7 @@ func TestSkill_Handle(t *testing.T) {
 	}
 
 	for _, test := range tests {
+		t.Logf("Testing: %s", test.name)
 		// Override mocked functions
 		if test.requestBootstrapFromJSON != nil {
 			requestBootstrapFromJSON = test.requestBootstrapFromJSON
@@ -376,47 +386,16 @@ func TestSkill_Handle(t *testing.T) {
 
 		if string(b) != test.written {
 			t.Errorf("%s: write mismatch:\n\tgot:    %v\n\texpected:%s", test.name, string(b), test.written)
-
 		}
-
 	}
-	/*
-	   	s := Skill{
-	   		ValidApplicationIDs: []string{"Test"},
-	   		OnIntent: func(request *request.IntentRequest, session *request.Session) (*response.Envelope, error) {
-	   			fmt.Printf("Request: %#v\n", *request)
-	   			fmt.Printf("Session: %#v\n", *session)
-
-	   			resp := response.NewResponse()
-	   			resp.OutputSpeech("Hello World")
-	   			resp.EndSession(true)
-	   			resp.SessionAttributes = session.Attributes
-	   			resp.SimpleCard("title", "content")
-
-	   			return resp, nil
-	   		},
-	   	}
-
-	   	buf := bytes.NewBuffer(nil)
-	   	if err := s.Handle(buf, []byte(`{
-	   		"version": "testVersion",
-	           "session": {
-	               "application": {
-	                   "applicationId": "Test"
-	               }
-	           },
-	   		"request": {
-	   	"type": "IntentRequest",
-	   	"dialogState": "testDialogState"
-	   	}
-	   	}`)); err != nil {
-	   		fmt.Printf("Got an error! %v", err)
-	   	}
-
-	   	fmt.Printf("Written response: %s", buf.String())*/
 }
 
 /* Test helper functions */
+
+type testingiface interface {
+	Logf(format string, args ...interface{})
+	Errorf(format string, args ...interface{})
+}
 
 type badReadWriter struct {
 	n   int


### PR DESCRIPTION
# Notes

- Type: cleanup
- Issue: #22

This code change removes all dependencies on the 3rd party package `github.com/pkg/errors` in favor of the standard library's `errors` package. It also removes the dependency on the standard library's `fmt` package. A benchmark was added to test the impact of this change.

# Coverage

- 100% line coverage

# Testing

- `go test customskill\` - passes
- `go test customskill\request` - passes
- `go test customskill\response` - passes

# Benchmark

- `cd customskill && go test -bench .` - passes @ ~130k ns/op. Previous code appears to be about ~140k ns/op.

  
  