### PR TITLE
[Refactor] Add metadata to customskill handlers

### DIFF
--- a/customskill/examples/http.go
+++ b/customskill/examples/http.go
@@ -36,10 +36,9 @@ func main() {
 	http.ListenAndServe(":8080", nil)
 }
 
-func onLaunch(launchRequest *request.LaunchRequest) (*response.Response, map[string]interface{}, error) {
+func onLaunch(launchRequest *request.LaunchRequest, metadata *request.Metadata) (*response.Response, map[string]interface{}, error) {
 	resp := response.New()
 	resp.SetEndSession(response.Bool(true))
-	sessAttrs := make(map[string]interface{})
-	sessAttrs["hello"] = "world"
-	return resp, sessAttrs, nil
+	metadata.Session.Attributes["hello"] = "world"
+	return resp, metadata.Session.Attributes, nil
 }

--- a/customskill/skill.go
+++ b/customskill/skill.go
@@ -40,7 +40,7 @@ func (s *Skill) Handle(w io.Writer, b []byte) error {
 			return errors.New("no OnLaunch handler defined")
 		}
 		lr := e.(*request.LaunchRequest)
-		resp, sess, err = s.OnLaunch(lr)
+		resp, sess, err = s.OnLaunch(lr, m)
 		if err != nil {
 			return errors.New("OnLaunch handler failed: " + err.Error())
 		}
@@ -49,7 +49,7 @@ func (s *Skill) Handle(w io.Writer, b []byte) error {
 			return errors.New("no OnIntent handler defined")
 		}
 		ir := e.(*request.IntentRequest)
-		resp, sess, err = s.OnIntent(ir, &m.Session)
+		resp, sess, err = s.OnIntent(ir, m)
 		if err != nil {
 			return errors.New("OnIntent handler failed: " + err.Error())
 		}
@@ -58,8 +58,8 @@ func (s *Skill) Handle(w io.Writer, b []byte) error {
 			return errors.New("no OnSessionEnded handler defined")
 		}
 		ser := e.(*request.SessionEndedRequest)
-		if err = s.OnSessionEnded(ser); err != nil {
-			return errors.New("OnSessionEnded handler failed: " + err.Error())
+		if err = s.OnSessionEnded(ser, m); err != nil {
+			return errors.New("OnSessionEnded handler failed:" + err.Error())
 		}
 		// A skill cannot return a response to SessionEndedRequest.
 		return nil

--- a/customskill/skill_test.go
+++ b/customskill/skill_test.go
@@ -38,7 +38,7 @@ func handleTests(t testingiface) {
 			name: "happy-path-launch-request",
 			skill: &Skill{
 				ValidApplicationIDs: []string{"testApplicationId"},
-				OnLaunch: func(request *request.LaunchRequest) (*response.Response, map[string]interface{}, error) {
+				OnLaunch: func(request *request.LaunchRequest, metadata *request.Metadata) (*response.Response, map[string]interface{}, error) {
 					sessAttrs := make(map[string]interface{})
 					sessAttrs["name"] = "happy-path-launch-request"
 					return response.New(), sessAttrs, nil
@@ -62,7 +62,7 @@ func handleTests(t testingiface) {
 			name: "happy-path-intent-request",
 			skill: &Skill{
 				ValidApplicationIDs: []string{"testApplicationId"},
-				OnIntent: func(intentRequest *request.IntentRequest, session *request.Session) (*response.Response, map[string]interface{}, error) {
+				OnIntent: func(intentRequest *request.IntentRequest, metadata *request.Metadata) (*response.Response, map[string]interface{}, error) {
 					sessAttrs := make(map[string]interface{})
 					sessAttrs["name"] = "happy-path-intent-request"
 					return response.New(), sessAttrs, nil
@@ -86,9 +86,9 @@ func handleTests(t testingiface) {
 			name: "happy-path-intent-request-with-session-attributes",
 			skill: &Skill{
 				ValidApplicationIDs: []string{"testApplicationId"},
-				OnIntent: func(intentRequest *request.IntentRequest, session *request.Session) (*response.Response, map[string]interface{}, error) {
-					session.Attributes["name"] = "happy-path-intent-request-with-session-attributes"
-					return response.New(), session.Attributes, nil
+				OnIntent: func(intentRequest *request.IntentRequest, metadata *request.Metadata) (*response.Response, map[string]interface{}, error) {
+					metadata.Session.Attributes["name"] = "happy-path-intent-request-with-session-attributes"
+					return response.New(), metadata.Session.Attributes, nil
 				},
 			},
 			b: `
@@ -110,7 +110,7 @@ func handleTests(t testingiface) {
 			name: "happy-path-session-ended-request",
 			skill: &Skill{
 				ValidApplicationIDs: []string{"testApplicationId"},
-				OnSessionEnded: func(endedRequest *request.SessionEndedRequest) error {
+				OnSessionEnded: func(endedRequest *request.SessionEndedRequest, metadata *request.Metadata) error {
 					return nil
 				},
 			},
@@ -203,7 +203,7 @@ func handleTests(t testingiface) {
 			name: "on-launch-request-handler-error-returns-error",
 			skill: &Skill{
 				ValidApplicationIDs: []string{"testApplicationId"},
-				OnLaunch: func(request *request.LaunchRequest) (*response.Response, map[string]interface{}, error) {
+				OnLaunch: func(request *request.LaunchRequest, metadata *request.Metadata) (*response.Response, map[string]interface{}, error) {
 					return nil, nil, errors.New("dummy error")
 				},
 			},
@@ -242,7 +242,7 @@ func handleTests(t testingiface) {
 			name: "on-intent-request-handler-error-returns-error",
 			skill: &Skill{
 				ValidApplicationIDs: []string{"testApplicationId"},
-				OnIntent: func(intentRequest *request.IntentRequest, session *request.Session) (*response.Response, map[string]interface{}, error) {
+				OnIntent: func(intentRequest *request.IntentRequest, metadata *request.Metadata) (*response.Response, map[string]interface{}, error) {
 					return nil, nil, errors.New("dummy error")
 				},
 			},
@@ -281,7 +281,7 @@ func handleTests(t testingiface) {
 			name: "on-session-ended-request-handler-error-returns-error",
 			skill: &Skill{
 				ValidApplicationIDs: []string{"testApplicationId"},
-				OnSessionEnded: func(endedRequest *request.SessionEndedRequest) error {
+				OnSessionEnded: func(endedRequest *request.SessionEndedRequest, metadata *request.Metadata) error {
 					return errors.New("dummy error")
 				},
 			},
@@ -302,7 +302,7 @@ func handleTests(t testingiface) {
 			name: "responses-which-cannot-be-marshalled-returns-error",
 			skill: &Skill{
 				ValidApplicationIDs: []string{"testApplicationId"},
-				OnLaunch: func(request *request.LaunchRequest) (*response.Response, map[string]interface{}, error) {
+				OnLaunch: func(request *request.LaunchRequest, metadata *request.Metadata) (*response.Response, map[string]interface{}, error) {
 					return nil, nil, nil
 				},
 			},
@@ -326,7 +326,7 @@ func handleTests(t testingiface) {
 			name: "writer-which-cannot-be-written-returns-error",
 			skill: &Skill{
 				ValidApplicationIDs: []string{"testApplicationId"},
-				OnLaunch: func(request *request.LaunchRequest) (*response.Response, map[string]interface{}, error) {
+				OnLaunch: func(request *request.LaunchRequest, metadata *request.Metadata) (*response.Response, map[string]interface{}, error) {
 					return nil, nil, nil
 				},
 			},
@@ -350,7 +350,7 @@ func handleTests(t testingiface) {
 			name: "writer-which-partially-writes-returns-error",
 			skill: &Skill{
 				ValidApplicationIDs: []string{"testApplicationId"},
-				OnLaunch: func(request *request.LaunchRequest) (*response.Response, map[string]interface{}, error) {
+				OnLaunch: func(request *request.LaunchRequest, metadata *request.Metadata) (*response.Response, map[string]interface{}, error) {
 					return nil, nil, nil
 				},
 			},

--- a/customskill/types.go
+++ b/customskill/types.go
@@ -8,7 +8,7 @@ import (
 // A Skill represents an Alexa custom skill.
 type Skill struct {
 	ValidApplicationIDs []string
-	OnLaunch            func(*request.LaunchRequest) (*response.Response, map[string]interface{}, error)
-	OnIntent            func(*request.IntentRequest, *request.Session) (*response.Response, map[string]interface{}, error)
-	OnSessionEnded      func(*request.SessionEndedRequest) error
+	OnLaunch            func(*request.LaunchRequest, *request.Metadata) (*response.Response, map[string]interface{}, error)
+	OnIntent            func(*request.IntentRequest, *request.Metadata) (*response.Response, map[string]interface{}, error)
+	OnSessionEnded      func(*request.SessionEndedRequest, *request.Metadata) error
 }


### PR DESCRIPTION
# Notes

- Type: feature
- Issue: #22

This code change exposes the request metadata to the skill handler instead of just the session attributes. This is required if the skill wants to pull useful information such as the user's access token.

# Coverage

- 100% line coverage

# Testing

- `go test customskill\` - passes