### PR TITLE
Refactor cleanup tests

### DIFF
--- a/customskill/examples/http.go
+++ b/customskill/examples/http.go
@@ -36,10 +36,9 @@ func main() {
 	http.ListenAndServe(":8080", nil)
 }
 
-func onLaunch(launchRequest *request.LaunchRequest) (*response.Response, map[string]interface{}, error) {
+func onLaunch(launchRequest *request.LaunchRequest, metadata *request.Metadata) (*response.Response, map[string]interface{}, error) {
 	resp := response.New()
 	resp.SetEndSession(response.Bool(true))
-	sessAttrs := make(map[string]interface{})
-	sessAttrs["hello"] = "world"
-	return resp, sessAttrs, nil
+	metadata.Session.Attributes["hello"] = "world"
+	return resp, metadata.Session.Attributes, nil
 }

--- a/customskill/request/request_test.go
+++ b/customskill/request/request_test.go
@@ -207,7 +207,7 @@ func TestRequest_BootstrapFromJSON(t *testing.T) {
 			// Exercise the function being tested.
 			m, r, err := BootstrapFromJSON([]byte(test.payload))
 			if !errorContains(err, test.partialErrorMessage) {
-				t.Errorf("error mismatch:\n\tgot:    %v\n\texpected: it to contain %s", err, pointerStr(test.partialErrorMessage))
+				t.Errorf("error mismatch:\n\tgot:    %v\n\twanted: it to contain %s", err, pointerStr(test.partialErrorMessage))
 				return
 			}
 
@@ -216,11 +216,11 @@ func TestRequest_BootstrapFromJSON(t *testing.T) {
 			}
 
 			if !reflect.DeepEqual(*m, *test.metadata) {
-				t.Errorf("metadata mismatch:\n\tgot:    %#v\n\twanted: %#v", *m, *test.metadata)
+				t.Errorf("metadata mismatch: got: %+v, wanted: %+v", *m, *test.metadata)
 			}
 
 			if !reflect.DeepEqual(r, test.request) {
-				t.Errorf("request mismatch:\n\tgot:    %#v\n\twanted: %#v", r, test.request)
+				t.Errorf("request mismatch: got: %+v, wanted: %+v", r, test.request)
 			}
 		})
 	}

--- a/customskill/request/request_test.go
+++ b/customskill/request/request_test.go
@@ -195,8 +195,16 @@ func TestRequest_BootstrapFromJSON(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			// Record & restore original functions.
+			jsonUnmarshalOriginal := jsonUnmarshal
+			defer func() {
+				jsonUnmarshal = jsonUnmarshalOriginal
+			}()
+
+			// Override mocked functions.
 			jsonUnmarshal = test.jsonUnmarshal
 
+			// Exercise the function being tested.
 			m, r, err := BootstrapFromJSON([]byte(test.payload))
 			if !errorContains(err, test.partialErrorMessage) {
 				t.Errorf("error mismatch:\n\tgot:    %v\n\texpected: it to contain %s", err, pointerStr(test.partialErrorMessage))

--- a/customskill/request/request_test.go
+++ b/customskill/request/request_test.go
@@ -194,25 +194,27 @@ func TestRequest_BootstrapFromJSON(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		jsonUnmarshal = test.jsonUnmarshal
+		t.Run(test.name, func(t *testing.T) {
+			jsonUnmarshal = test.jsonUnmarshal
 
-		m, r, err := BootstrapFromJSON([]byte(test.payload))
-		if !errorContains(err, test.partialErrorMessage) {
-			t.Errorf("%s: error mismatch:\n\tgot:    %v\n\texpected: it to contain %s", test.name, err, pointerStr(test.partialErrorMessage))
-			continue
-		}
+			m, r, err := BootstrapFromJSON([]byte(test.payload))
+			if !errorContains(err, test.partialErrorMessage) {
+				t.Errorf("error mismatch:\n\tgot:    %v\n\texpected: it to contain %s", err, pointerStr(test.partialErrorMessage))
+				return
+			}
 
-		if test.partialErrorMessage != nil {
-			continue
-		}
+			if test.partialErrorMessage != nil {
+				return
+			}
 
-		if !reflect.DeepEqual(*m, *test.metadata) {
-			t.Errorf("%s: metadata mismatch:\n\tgot:    %#v\n\twanted: %#v", test.name, *m, *test.metadata)
-		}
+			if !reflect.DeepEqual(*m, *test.metadata) {
+				t.Errorf("metadata mismatch:\n\tgot:    %#v\n\twanted: %#v", *m, *test.metadata)
+			}
 
-		if !reflect.DeepEqual(r, test.request) {
-			t.Errorf("%s: request mismatch:\n\tgot:    %#v\n\twanted: %#v", test.name, r, test.request)
-		}
+			if !reflect.DeepEqual(r, test.request) {
+				t.Errorf("request mismatch:\n\tgot:    %#v\n\twanted: %#v", r, test.request)
+			}
+		})
 	}
 }
 

--- a/customskill/skill.go
+++ b/customskill/skill.go
@@ -40,7 +40,7 @@ func (s *Skill) Handle(w io.Writer, b []byte) error {
 			return errors.New("no OnLaunch handler defined")
 		}
 		lr := e.(*request.LaunchRequest)
-		resp, sess, err = s.OnLaunch(lr)
+		resp, sess, err = s.OnLaunch(lr, m)
 		if err != nil {
 			return errors.New("OnLaunch handler failed: " + err.Error())
 		}
@@ -49,7 +49,7 @@ func (s *Skill) Handle(w io.Writer, b []byte) error {
 			return errors.New("no OnIntent handler defined")
 		}
 		ir := e.(*request.IntentRequest)
-		resp, sess, err = s.OnIntent(ir, &m.Session)
+		resp, sess, err = s.OnIntent(ir, m)
 		if err != nil {
 			return errors.New("OnIntent handler failed: " + err.Error())
 		}
@@ -58,8 +58,8 @@ func (s *Skill) Handle(w io.Writer, b []byte) error {
 			return errors.New("no OnSessionEnded handler defined")
 		}
 		ser := e.(*request.SessionEndedRequest)
-		if err = s.OnSessionEnded(ser); err != nil {
-			return errors.New("OnSessionEnded handler failed: " + err.Error())
+		if err = s.OnSessionEnded(ser, m); err != nil {
+			return errors.New("OnSessionEnded handler failed:" + err.Error())
 		}
 		// A skill cannot return a response to SessionEndedRequest.
 		return nil

--- a/customskill/skill_test.go
+++ b/customskill/skill_test.go
@@ -14,16 +14,6 @@ import (
 )
 
 func TestSkill_Handle(t *testing.T) {
-	handleTests(t)
-}
-
-func BenchmarkSkill_Handle(b *testing.B) {
-	for n := 0; n < b.N; n++ {
-		handleTests(b)
-	}
-}
-
-func handleTests(t testingiface) {
 	var tests = []struct {
 		name                     string
 		skill                    *Skill
@@ -407,11 +397,6 @@ func handleTests(t testingiface) {
 }
 
 /* Test helper functions */
-
-type testingiface interface {
-	Logf(format string, args ...interface{})
-	Errorf(format string, args ...interface{})
-}
 
 type badReadWriter struct {
 	n   int

--- a/customskill/skill_test.go
+++ b/customskill/skill_test.go
@@ -382,7 +382,7 @@ func TestSkill_Handle(t *testing.T) {
 			// Exercise the function being tested.
 			err := test.skill.Handle(test.w, []byte(test.b))
 			if !errorContains(err, test.partialErrorMessage) {
-				t.Errorf("error mismatch:\n\tgot:    %v\n\twanted: it to contain '%s'", err, pointerStr(test.partialErrorMessage))
+				t.Errorf("error mismatch: got: %+v, wanted: it to contain '%s'", err, pointerStr(test.partialErrorMessage))
 				return
 			}
 
@@ -396,7 +396,7 @@ func TestSkill_Handle(t *testing.T) {
 			}
 
 			if string(b) != test.written {
-				t.Errorf("write mismatch:\n\tgot:    %v\n\texpected:%s", string(b), test.written)
+				t.Errorf("write mismatch: got: %+v, wanted: %s", string(b), test.written)
 			}
 		})
 	}

--- a/customskill/skill_test.go
+++ b/customskill/skill_test.go
@@ -38,7 +38,7 @@ func handleTests(t testingiface) {
 			name: "happy-path-launch-request",
 			skill: &Skill{
 				ValidApplicationIDs: []string{"testApplicationId"},
-				OnLaunch: func(request *request.LaunchRequest) (*response.Response, map[string]interface{}, error) {
+				OnLaunch: func(request *request.LaunchRequest, metadata *request.Metadata) (*response.Response, map[string]interface{}, error) {
 					sessAttrs := make(map[string]interface{})
 					sessAttrs["name"] = "happy-path-launch-request"
 					return response.New(), sessAttrs, nil
@@ -62,7 +62,7 @@ func handleTests(t testingiface) {
 			name: "happy-path-intent-request",
 			skill: &Skill{
 				ValidApplicationIDs: []string{"testApplicationId"},
-				OnIntent: func(intentRequest *request.IntentRequest, session *request.Session) (*response.Response, map[string]interface{}, error) {
+				OnIntent: func(intentRequest *request.IntentRequest, metadata *request.Metadata) (*response.Response, map[string]interface{}, error) {
 					sessAttrs := make(map[string]interface{})
 					sessAttrs["name"] = "happy-path-intent-request"
 					return response.New(), sessAttrs, nil
@@ -86,9 +86,9 @@ func handleTests(t testingiface) {
 			name: "happy-path-intent-request-with-session-attributes",
 			skill: &Skill{
 				ValidApplicationIDs: []string{"testApplicationId"},
-				OnIntent: func(intentRequest *request.IntentRequest, session *request.Session) (*response.Response, map[string]interface{}, error) {
-					session.Attributes["name"] = "happy-path-intent-request-with-session-attributes"
-					return response.New(), session.Attributes, nil
+				OnIntent: func(intentRequest *request.IntentRequest, metadata *request.Metadata) (*response.Response, map[string]interface{}, error) {
+					metadata.Session.Attributes["name"] = "happy-path-intent-request-with-session-attributes"
+					return response.New(), metadata.Session.Attributes, nil
 				},
 			},
 			b: `
@@ -110,7 +110,7 @@ func handleTests(t testingiface) {
 			name: "happy-path-session-ended-request",
 			skill: &Skill{
 				ValidApplicationIDs: []string{"testApplicationId"},
-				OnSessionEnded: func(endedRequest *request.SessionEndedRequest) error {
+				OnSessionEnded: func(endedRequest *request.SessionEndedRequest, metadata *request.Metadata) error {
 					return nil
 				},
 			},
@@ -203,7 +203,7 @@ func handleTests(t testingiface) {
 			name: "on-launch-request-handler-error-returns-error",
 			skill: &Skill{
 				ValidApplicationIDs: []string{"testApplicationId"},
-				OnLaunch: func(request *request.LaunchRequest) (*response.Response, map[string]interface{}, error) {
+				OnLaunch: func(request *request.LaunchRequest, metadata *request.Metadata) (*response.Response, map[string]interface{}, error) {
 					return nil, nil, errors.New("dummy error")
 				},
 			},
@@ -242,7 +242,7 @@ func handleTests(t testingiface) {
 			name: "on-intent-request-handler-error-returns-error",
 			skill: &Skill{
 				ValidApplicationIDs: []string{"testApplicationId"},
-				OnIntent: func(intentRequest *request.IntentRequest, session *request.Session) (*response.Response, map[string]interface{}, error) {
+				OnIntent: func(intentRequest *request.IntentRequest, metadata *request.Metadata) (*response.Response, map[string]interface{}, error) {
 					return nil, nil, errors.New("dummy error")
 				},
 			},
@@ -281,7 +281,7 @@ func handleTests(t testingiface) {
 			name: "on-session-ended-request-handler-error-returns-error",
 			skill: &Skill{
 				ValidApplicationIDs: []string{"testApplicationId"},
-				OnSessionEnded: func(endedRequest *request.SessionEndedRequest) error {
+				OnSessionEnded: func(endedRequest *request.SessionEndedRequest, metadata *request.Metadata) error {
 					return errors.New("dummy error")
 				},
 			},
@@ -302,7 +302,7 @@ func handleTests(t testingiface) {
 			name: "responses-which-cannot-be-marshalled-returns-error",
 			skill: &Skill{
 				ValidApplicationIDs: []string{"testApplicationId"},
-				OnLaunch: func(request *request.LaunchRequest) (*response.Response, map[string]interface{}, error) {
+				OnLaunch: func(request *request.LaunchRequest, metadata *request.Metadata) (*response.Response, map[string]interface{}, error) {
 					return nil, nil, nil
 				},
 			},
@@ -326,7 +326,7 @@ func handleTests(t testingiface) {
 			name: "writer-which-cannot-be-written-returns-error",
 			skill: &Skill{
 				ValidApplicationIDs: []string{"testApplicationId"},
-				OnLaunch: func(request *request.LaunchRequest) (*response.Response, map[string]interface{}, error) {
+				OnLaunch: func(request *request.LaunchRequest, metadata *request.Metadata) (*response.Response, map[string]interface{}, error) {
 					return nil, nil, nil
 				},
 			},
@@ -350,7 +350,7 @@ func handleTests(t testingiface) {
 			name: "writer-which-partially-writes-returns-error",
 			skill: &Skill{
 				ValidApplicationIDs: []string{"testApplicationId"},
-				OnLaunch: func(request *request.LaunchRequest) (*response.Response, map[string]interface{}, error) {
+				OnLaunch: func(request *request.LaunchRequest, metadata *request.Metadata) (*response.Response, map[string]interface{}, error) {
 					return nil, nil, nil
 				},
 			},

--- a/customskill/skill_test.go
+++ b/customskill/skill_test.go
@@ -363,36 +363,37 @@ func TestSkill_Handle(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		t.Logf("Testing: %s", test.name)
-		// Override mocked functions
-		if test.requestBootstrapFromJSON != nil {
-			requestBootstrapFromJSON = test.requestBootstrapFromJSON
-		}
-		if test.jsonMarshal != nil {
-			jsonMarshal = test.jsonMarshal
-		}
-		err := test.skill.Handle(test.w, []byte(test.b))
-		if !errorContains(err, test.partialErrorMessage) {
-			t.Errorf("%s: error mismatch:\n\tgot:    %v\n\twanted: it to contain '%s'", test.name, err, pointerStr(test.partialErrorMessage))
-			continue
-		}
+		t.Run(test.name, func(t *testing.T) {
+			// Override mocked functions
+			if test.requestBootstrapFromJSON != nil {
+				requestBootstrapFromJSON = test.requestBootstrapFromJSON
+			}
+			if test.jsonMarshal != nil {
+				jsonMarshal = test.jsonMarshal
+			}
+			err := test.skill.Handle(test.w, []byte(test.b))
+			if !errorContains(err, test.partialErrorMessage) {
+				t.Errorf("error mismatch:\n\tgot:    %v\n\twanted: it to contain '%s'", err, pointerStr(test.partialErrorMessage))
+				return
+			}
 
-		// Restore mocked functions
-		requestBootstrapFromJSON = request.BootstrapFromJSON
-		jsonMarshal = json.Marshal
+			// Restore mocked functions
+			requestBootstrapFromJSON = request.BootstrapFromJSON
+			jsonMarshal = json.Marshal
 
-		if test.partialErrorMessage != nil {
-			continue
-		}
+			if test.partialErrorMessage != nil {
+				return
+			}
 
-		b, err := ioutil.ReadAll(test.w)
-		if err != nil {
-			t.Errorf("%s: failed to read test writer: %v", test.name, err)
-		}
+			b, err := ioutil.ReadAll(test.w)
+			if err != nil {
+				t.Errorf("failed to read test writer: %v", err)
+			}
 
-		if string(b) != test.written {
-			t.Errorf("%s: write mismatch:\n\tgot:    %v\n\texpected:%s", test.name, string(b), test.written)
-		}
+			if string(b) != test.written {
+				t.Errorf("write mismatch:\n\tgot:    %v\n\texpected:%s", string(b), test.written)
+			}
+		})
 	}
 }
 

--- a/customskill/types.go
+++ b/customskill/types.go
@@ -8,7 +8,7 @@ import (
 // A Skill represents an Alexa custom skill.
 type Skill struct {
 	ValidApplicationIDs []string
-	OnLaunch            func(*request.LaunchRequest) (*response.Response, map[string]interface{}, error)
-	OnIntent            func(*request.IntentRequest, *request.Session) (*response.Response, map[string]interface{}, error)
-	OnSessionEnded      func(*request.SessionEndedRequest) error
+	OnLaunch            func(*request.LaunchRequest, *request.Metadata) (*response.Response, map[string]interface{}, error)
+	OnIntent            func(*request.IntentRequest, *request.Metadata) (*response.Response, map[string]interface{}, error)
+	OnSessionEnded      func(*request.SessionEndedRequest, *request.Metadata) error
 }

--- a/ssml/builder_test.go
+++ b/ssml/builder_test.go
@@ -65,18 +65,20 @@ func TestBuilder_AppendAmazonEffect(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		b, _ := NewBuilder()
+		t.Run(test.name, func(t *testing.T) {
+			b, _ := NewBuilder()
 
-		b.AppendAmazonEffect(test.effect, "text1").AppendAmazonEffect(test.effect, "text2")
+			b.AppendAmazonEffect(test.effect, "text1").AppendAmazonEffect(test.effect, "text2")
 
-		actual, errs := b.Build()
-		if !errsEqual(nil, errs) {
-			t.Errorf("%s: error mismatch: expected nil, got %v", test.name, errs)
-		}
+			actual, errs := b.Build()
+			if !errsEqual(nil, errs) {
+				t.Errorf("error mismatch: expected nil, got %v", errs)
+			}
 
-		if actual != test.expected {
-			t.Errorf("%s: output mismatch: expected %s, got %s", test.name, test.expected, actual)
-		}
+			if actual != test.expected {
+				t.Errorf("output mismatch: expected %s, got %s", test.expected, actual)
+			}
+		})
 	}
 }
 
@@ -114,18 +116,20 @@ func TestBuilder_AppendAudio(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		b, _ := NewBuilder()
+		t.Run(test.name, func(t *testing.T) {
+			b, _ := NewBuilder()
 
-		b.AppendAudio(test.src).AppendAudio(test.src)
+			b.AppendAudio(test.src).AppendAudio(test.src)
 
-		actual, errs := b.Build()
-		if !errsEqual(test.errs, errs) {
-			t.Errorf("%s: error mismatch: expected %+v, got %+v", test.name, test.errs, errs)
-		}
+			actual, errs := b.Build()
+			if !errsEqual(test.errs, errs) {
+				t.Errorf("error mismatch: expected %+v, got %+v", test.errs, errs)
+			}
 
-		if actual != test.expected {
-			t.Errorf("%s: output mismatch: expected %s, got %s", test.name, test.expected, actual)
-		}
+			if actual != test.expected {
+				t.Errorf("output mismatch: expected %s, got %s", test.expected, actual)
+			}
+		})
 	}
 }
 
@@ -202,18 +206,20 @@ func TestBuilder_AppendBreak(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		b, _ := NewBuilder()
+		t.Run(test.name, func(t *testing.T) {
+			b, _ := NewBuilder()
 
-		b.AppendBreak(test.param).AppendBreak(test.param)
+			b.AppendBreak(test.param).AppendBreak(test.param)
 
-		actual, errs := b.Build()
-		if !errsEqual(test.errs, errs) {
-			t.Errorf("%s: error mismatch: expected %v, got %v", test.name, test.errs, errs)
-		}
+			actual, errs := b.Build()
+			if !errsEqual(test.errs, errs) {
+				t.Errorf("error mismatch: expected %v, got %v", test.errs, errs)
+			}
 
-		if actual != test.expected {
-			t.Errorf("%s: output mismatch: expected %s, got %s", test.name, test.expected, actual)
-		}
+			if actual != test.expected {
+				t.Errorf("output mismatch: expected %s, got %s", test.expected, actual)
+			}
+		})
 	}
 }
 
@@ -252,18 +258,20 @@ func TestBuilder_AppendEmphasis(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		b, _ := NewBuilder()
+		t.Run(test.name, func(t *testing.T) {
+			b, _ := NewBuilder()
 
-		b.AppendEmphasis(test.level, "text1").AppendEmphasis(test.level, "text2")
+			b.AppendEmphasis(test.level, "text1").AppendEmphasis(test.level, "text2")
 
-		actual, errs := b.Build()
-		if !errsEqual(nil, errs) {
-			t.Errorf("%s: error mismatch: expected nil, got %v", test.name, errs)
-		}
+			actual, errs := b.Build()
+			if !errsEqual(nil, errs) {
+				t.Errorf("error mismatch: expected nil, got %v", errs)
+			}
 
-		if actual != test.expected {
-			t.Errorf("%s: output mismatch: expected %s, got %s", test.name, test.expected, actual)
-		}
+			if actual != test.expected {
+				t.Errorf("output mismatch: expected %s, got %s", test.expected, actual)
+			}
+		})
 	}
 }
 
@@ -456,18 +464,20 @@ func TestBuilder_AppendProsody(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		b, _ := NewBuilder()
+		t.Run(test.name, func(t *testing.T) {
+			b, _ := NewBuilder()
 
-		b.AppendProsody(test.rate, test.pitch, test.volume, "text1").AppendProsody(test.rate, test.pitch, test.volume, "text2")
+			b.AppendProsody(test.rate, test.pitch, test.volume, "text1").AppendProsody(test.rate, test.pitch, test.volume, "text2")
 
-		actual, errs := b.Build()
-		if !errsEqual(test.errs, errs) {
-			t.Errorf("%s: error mismatch: expected %v, got %v", test.name, test.errs, errs)
-		}
+			actual, errs := b.Build()
+			if !errsEqual(test.errs, errs) {
+				t.Errorf("error mismatch: expected %v, got %v", test.errs, errs)
+			}
 
-		if actual != test.expected {
-			t.Errorf("%s: output mismatch: expected %s, got %s", test.name, test.expected, actual)
-		}
+			if actual != test.expected {
+				t.Errorf("output mismatch: expected %s, got %s", test.expected, actual)
+			}
+		})
 	}
 }
 

--- a/ssml/builder_test.go
+++ b/ssml/builder_test.go
@@ -16,17 +16,17 @@ func TestNewBuilder_ReturnsEmptySSML(t *testing.T) {
 	b, err := NewBuilder()
 
 	if err != nil {
-		t.Fatalf("failed to get new builder: expected no error, got :%v", err)
+		t.Fatalf("new error mismatch: got: %+v, wanted: nil", err)
 	}
 
-	actual, errs := b.Build()
+	got, errs := b.Build()
 	if !errsEqual(nil, errs) {
-		t.Errorf("error mismatch: expected nil, got %v", errs)
+		t.Errorf("build error mismatch: got: %+v, wanted: nil", errs)
 	}
 
-	expected := "<speak></speak>"
-	if actual != expected {
-		t.Errorf("output mismatch: expected %s, got %s", expected, actual)
+	wanted := "<speak></speak>"
+	if got != wanted {
+		t.Errorf("output mismatch: got: %s, wanted: %s", got, wanted)
 	}
 }
 
@@ -35,32 +35,32 @@ func TestBuilder_AppendPlainSpeech(t *testing.T) {
 
 	b.AppendPlainSpeech("hello ").AppendPlainSpeech("world")
 
-	actual, errs := b.Build()
+	got, errs := b.Build()
 	if !errsEqual(nil, errs) {
-		t.Errorf("error mismatch: expected nil, got %v", errs)
+		t.Errorf("error mismatch: got: %+v, wanted: nil", errs)
 	}
 
-	expected := "<speak>hello world</speak>"
-	if actual != expected {
-		t.Errorf("output mismatch: expected %s, got %s", expected, actual)
+	wanted := "<speak>hello world</speak>"
+	if got != wanted {
+		t.Errorf("output mismatch: got: %s, wanted: %s", got, wanted)
 	}
 }
 
 func TestBuilder_AppendAmazonEffect(t *testing.T) {
 	tests := []struct {
-		name     string
-		effect   amazoneffect.Effect
-		expected string
+		name   string
+		effect amazoneffect.Effect
+		wanted string
 	}{
 		{
-			name:     "whispered",
-			effect:   amazoneffect.Whispered,
-			expected: `<speak><amazon:effect name="whispered">text1</amazon:effect><amazon:effect name="whispered">text2</amazon:effect></speak>`,
+			name:   "whispered",
+			effect: amazoneffect.Whispered,
+			wanted: `<speak><amazon:effect name="whispered">text1</amazon:effect><amazon:effect name="whispered">text2</amazon:effect></speak>`,
 		},
 		{
-			name:     "custom",
-			effect:   amazoneffect.Effect("custom"),
-			expected: `<speak><amazon:effect name="custom">text1</amazon:effect><amazon:effect name="custom">text2</amazon:effect></speak>`,
+			name:   "custom",
+			effect: amazoneffect.Effect("custom"),
+			wanted: `<speak><amazon:effect name="custom">text1</amazon:effect><amazon:effect name="custom">text2</amazon:effect></speak>`,
 		},
 	}
 
@@ -70,13 +70,13 @@ func TestBuilder_AppendAmazonEffect(t *testing.T) {
 
 			b.AppendAmazonEffect(test.effect, "text1").AppendAmazonEffect(test.effect, "text2")
 
-			actual, errs := b.Build()
+			got, errs := b.Build()
 			if !errsEqual(nil, errs) {
-				t.Errorf("error mismatch: expected nil, got %v", errs)
+				t.Errorf("error mismatch: got: %+v, wanted: nil", errs)
 			}
 
-			if actual != test.expected {
-				t.Errorf("output mismatch: expected %s, got %s", test.expected, actual)
+			if got != test.wanted {
+				t.Errorf("output mismatch: got: %s, wanted: %s", got, test.wanted)
 			}
 		})
 	}
@@ -84,16 +84,16 @@ func TestBuilder_AppendAmazonEffect(t *testing.T) {
 
 func TestBuilder_AppendAudio(t *testing.T) {
 	tests := []struct {
-		name     string
-		src      string
-		errs     []error
-		expected string
+		name   string
+		src    string
+		errs   []error
+		wanted string
 	}{
 		{
-			name:     "happyPath",
-			src:      "https://domain.tld",
-			errs:     nil,
-			expected: `<speak><audio src="https://domain.tld"/><audio src="https://domain.tld"/></speak>`,
+			name:   "happyPath",
+			src:    "https://domain.tld",
+			errs:   nil,
+			wanted: `<speak><audio src="https://domain.tld"/><audio src="https://domain.tld"/></speak>`,
 		},
 		{
 			name: "nonHTTPSUrl",
@@ -102,7 +102,7 @@ func TestBuilder_AppendAudio(t *testing.T) {
 				errors.New("unsupported URL scheme type: must be https"),
 				errors.New("unsupported URL scheme type: must be https"),
 			},
-			expected: `<speak></speak>`,
+			wanted: `<speak></speak>`,
 		},
 		{
 			name: "badUrl",
@@ -111,7 +111,7 @@ func TestBuilder_AppendAudio(t *testing.T) {
 				errors.New(`failed to parse src into a valid URL: parse %notarealurl: invalid URL escape "%no"`),
 				errors.New(`failed to parse src into a valid URL: parse %notarealurl: invalid URL escape "%no"`),
 			},
-			expected: `<speak></speak>`,
+			wanted: `<speak></speak>`,
 		},
 	}
 
@@ -121,13 +121,13 @@ func TestBuilder_AppendAudio(t *testing.T) {
 
 			b.AppendAudio(test.src).AppendAudio(test.src)
 
-			actual, errs := b.Build()
-			if !errsEqual(test.errs, errs) {
-				t.Errorf("error mismatch: expected %+v, got %+v", test.errs, errs)
+			got, errs := b.Build()
+			if !errsEqual(errs, test.errs) {
+				t.Errorf("error mismatch: got: %+v, wanted: %+v", errs, test.errs)
 			}
 
-			if actual != test.expected {
-				t.Errorf("output mismatch: expected %s, got %s", test.expected, actual)
+			if got != test.wanted {
+				t.Errorf("output mismatch: got: %s, wanted: %s", got, test.wanted)
 			}
 		})
 	}
@@ -135,64 +135,64 @@ func TestBuilder_AppendAudio(t *testing.T) {
 
 func TestBuilder_AppendBreak(t *testing.T) {
 	tests := []struct {
-		name     string
-		param    interface{}
-		errs     []error
-		expected string
+		name   string
+		param  interface{}
+		errs   []error
+		wanted string
 	}{
 		{
-			name:     "default",
-			param:    pause.Default,
-			errs:     nil,
-			expected: `<speak><break strength="medium"/><break strength="medium"/></speak>`,
+			name:   "default",
+			param:  pause.Default,
+			errs:   nil,
+			wanted: `<speak><break strength="medium"/><break strength="medium"/></speak>`,
 		},
 		{
-			name:     "none",
-			param:    pause.None,
-			errs:     nil,
-			expected: `<speak><break strength="none"/><break strength="none"/></speak>`,
+			name:   "none",
+			param:  pause.None,
+			errs:   nil,
+			wanted: `<speak><break strength="none"/><break strength="none"/></speak>`,
 		},
 		{
-			name:     "x-weak",
-			param:    pause.XWeak,
-			errs:     nil,
-			expected: `<speak><break strength="x-weak"/><break strength="x-weak"/></speak>`,
+			name:   "x-weak",
+			param:  pause.XWeak,
+			errs:   nil,
+			wanted: `<speak><break strength="x-weak"/><break strength="x-weak"/></speak>`,
 		},
 		{
-			name:     "weak",
-			param:    pause.Weak,
-			errs:     nil,
-			expected: `<speak><break strength="weak"/><break strength="weak"/></speak>`,
+			name:   "weak",
+			param:  pause.Weak,
+			errs:   nil,
+			wanted: `<speak><break strength="weak"/><break strength="weak"/></speak>`,
 		},
 		{
-			name:     "medium",
-			param:    pause.Medium,
-			errs:     nil,
-			expected: `<speak><break strength="medium"/><break strength="medium"/></speak>`,
+			name:   "medium",
+			param:  pause.Medium,
+			errs:   nil,
+			wanted: `<speak><break strength="medium"/><break strength="medium"/></speak>`,
 		},
 		{
-			name:     "strong",
-			param:    pause.Strong,
-			errs:     nil,
-			expected: `<speak><break strength="strong"/><break strength="strong"/></speak>`,
+			name:   "strong",
+			param:  pause.Strong,
+			errs:   nil,
+			wanted: `<speak><break strength="strong"/><break strength="strong"/></speak>`,
 		},
 		{
-			name:     "x-strong",
-			param:    pause.XStrong,
-			errs:     nil,
-			expected: `<speak><break strength="x-strong"/><break strength="x-strong"/></speak>`,
+			name:   "x-strong",
+			param:  pause.XStrong,
+			errs:   nil,
+			wanted: `<speak><break strength="x-strong"/><break strength="x-strong"/></speak>`,
 		},
 		{
-			name:     "custom",
-			param:    pause.Strength("custom"),
-			errs:     nil,
-			expected: `<speak><break strength="custom"/><break strength="custom"/></speak>`,
+			name:   "custom",
+			param:  pause.Strength("custom"),
+			errs:   nil,
+			wanted: `<speak><break strength="custom"/><break strength="custom"/></speak>`,
 		},
 		{
-			name:     "time",
-			param:    time.Second,
-			errs:     nil,
-			expected: `<speak><break time="1000ms"/><break time="1000ms"/></speak>`,
+			name:   "time",
+			param:  time.Second,
+			errs:   nil,
+			wanted: `<speak><break time="1000ms"/><break time="1000ms"/></speak>`,
 		},
 		{
 			name:  "invalidType",
@@ -201,7 +201,7 @@ func TestBuilder_AppendBreak(t *testing.T) {
 				errors.New("unsupported parameter type: must be either pause.Strength or time.Duration"),
 				errors.New("unsupported parameter type: must be either pause.Strength or time.Duration"),
 			},
-			expected: `<speak></speak>`,
+			wanted: `<speak></speak>`,
 		},
 	}
 
@@ -211,13 +211,13 @@ func TestBuilder_AppendBreak(t *testing.T) {
 
 			b.AppendBreak(test.param).AppendBreak(test.param)
 
-			actual, errs := b.Build()
-			if !errsEqual(test.errs, errs) {
-				t.Errorf("error mismatch: expected %v, got %v", test.errs, errs)
+			got, errs := b.Build()
+			if !errsEqual(errs, test.errs) {
+				t.Errorf("error mismatch: got: %+v, wanted: %+v", errs, test.errs)
 			}
 
-			if actual != test.expected {
-				t.Errorf("output mismatch: expected %s, got %s", test.expected, actual)
+			if got != test.wanted {
+				t.Errorf("output mismatch: got: %s, wanted: %s", got, test.wanted)
 			}
 		})
 	}
@@ -225,35 +225,35 @@ func TestBuilder_AppendBreak(t *testing.T) {
 
 func TestBuilder_AppendEmphasis(t *testing.T) {
 	tests := []struct {
-		name     string
-		level    emphasis.Level
-		text     string
-		expected string
+		name   string
+		level  emphasis.Level
+		text   string
+		wanted string
 	}{
 		{
-			name:     "default",
-			level:    emphasis.Default,
-			expected: `<speak><emphasis level="moderate">text1</emphasis><emphasis level="moderate">text2</emphasis></speak>`,
+			name:   "default",
+			level:  emphasis.Default,
+			wanted: `<speak><emphasis level="moderate">text1</emphasis><emphasis level="moderate">text2</emphasis></speak>`,
 		},
 		{
-			name:     "strong",
-			level:    emphasis.Strong,
-			expected: `<speak><emphasis level="strong">text1</emphasis><emphasis level="strong">text2</emphasis></speak>`,
+			name:   "strong",
+			level:  emphasis.Strong,
+			wanted: `<speak><emphasis level="strong">text1</emphasis><emphasis level="strong">text2</emphasis></speak>`,
 		},
 		{
-			name:     "moderate",
-			level:    emphasis.Moderate,
-			expected: `<speak><emphasis level="moderate">text1</emphasis><emphasis level="moderate">text2</emphasis></speak>`,
+			name:   "moderate",
+			level:  emphasis.Moderate,
+			wanted: `<speak><emphasis level="moderate">text1</emphasis><emphasis level="moderate">text2</emphasis></speak>`,
 		},
 		{
-			name:     "reduced",
-			level:    emphasis.Reduced,
-			expected: `<speak><emphasis level="reduced">text1</emphasis><emphasis level="reduced">text2</emphasis></speak>`,
+			name:   "reduced",
+			level:  emphasis.Reduced,
+			wanted: `<speak><emphasis level="reduced">text1</emphasis><emphasis level="reduced">text2</emphasis></speak>`,
 		},
 		{
-			name:     "reduced",
-			level:    emphasis.Level("custom"),
-			expected: `<speak><emphasis level="custom">text1</emphasis><emphasis level="custom">text2</emphasis></speak>`,
+			name:   "reduced",
+			level:  emphasis.Level("custom"),
+			wanted: `<speak><emphasis level="custom">text1</emphasis><emphasis level="custom">text2</emphasis></speak>`,
 		},
 	}
 
@@ -263,13 +263,13 @@ func TestBuilder_AppendEmphasis(t *testing.T) {
 
 			b.AppendEmphasis(test.level, "text1").AppendEmphasis(test.level, "text2")
 
-			actual, errs := b.Build()
+			got, errs := b.Build()
 			if !errsEqual(nil, errs) {
-				t.Errorf("error mismatch: expected nil, got %v", errs)
+				t.Errorf("error mismatch: got: %+v, wanted: nil", errs)
 			}
 
-			if actual != test.expected {
-				t.Errorf("output mismatch: expected %s, got %s", test.expected, actual)
+			if got != test.wanted {
+				t.Errorf("output mismatch: got: %s, wanted: %s", got, test.wanted)
 			}
 		})
 	}
@@ -280,153 +280,153 @@ func TestBuilder_AppendParagraph(t *testing.T) {
 
 	b.AppendParagraph("text1").AppendParagraph("text2")
 
-	actual, errs := b.Build()
+	got, errs := b.Build()
 	if !errsEqual(nil, errs) {
-		t.Errorf("error mismatch: expected nil, got %v", errs)
+		t.Errorf("error mismatch: got: %+v, wanted: nil", errs)
 	}
 
-	expected := `<speak><p>text1</p><p>text2</p></speak>`
-	if actual != expected {
-		t.Errorf("expected %s, got %s", expected, actual)
+	wanted := `<speak><p>text1</p><p>text2</p></speak>`
+	if got != wanted {
+		t.Errorf("got: %s, wanted: %s", got, wanted)
 	}
 }
 
 func TestBuilder_AppendProsody(t *testing.T) {
 	tests := []struct {
-		name     string
-		rate     interface{}
-		pitch    interface{}
-		volume   interface{}
-		errs     []error
-		expected string
+		name   string
+		rate   interface{}
+		pitch  interface{}
+		volume interface{}
+		errs   []error
+		wanted string
 	}{
 		{
-			name:     "x-slow, x-low, & silent",
-			rate:     prosody.RateXSlow,
-			pitch:    prosody.PitchXLow,
-			volume:   prosody.VolumeSilent,
-			errs:     nil,
-			expected: `<speak><prosody rate="x-slow" pitch="x-low" volume="silent">text1</prosody><prosody rate="x-slow" pitch="x-low" volume="silent">text2</prosody></speak>`,
+			name:   "x-slow, x-low, & silent",
+			rate:   prosody.RateXSlow,
+			pitch:  prosody.PitchXLow,
+			volume: prosody.VolumeSilent,
+			errs:   nil,
+			wanted: `<speak><prosody rate="x-slow" pitch="x-low" volume="silent">text1</prosody><prosody rate="x-slow" pitch="x-low" volume="silent">text2</prosody></speak>`,
 		},
 		{
-			name:     "slow, low, & x-soft",
-			rate:     prosody.RateSlow,
-			pitch:    prosody.PitchLow,
-			volume:   prosody.VolumeXSoft,
-			errs:     nil,
-			expected: `<speak><prosody rate="slow" pitch="low" volume="x-soft">text1</prosody><prosody rate="slow" pitch="low" volume="x-soft">text2</prosody></speak>`,
+			name:   "slow, low, & x-soft",
+			rate:   prosody.RateSlow,
+			pitch:  prosody.PitchLow,
+			volume: prosody.VolumeXSoft,
+			errs:   nil,
+			wanted: `<speak><prosody rate="slow" pitch="low" volume="x-soft">text1</prosody><prosody rate="slow" pitch="low" volume="x-soft">text2</prosody></speak>`,
 		},
 		{
-			name:     "medium, medium, & soft",
-			rate:     prosody.RateMedium,
-			pitch:    prosody.PitchMedium,
-			volume:   prosody.VolumeSoft,
-			errs:     nil,
-			expected: `<speak><prosody rate="medium" pitch="medium" volume="soft">text1</prosody><prosody rate="medium" pitch="medium" volume="soft">text2</prosody></speak>`,
+			name:   "medium, medium, & soft",
+			rate:   prosody.RateMedium,
+			pitch:  prosody.PitchMedium,
+			volume: prosody.VolumeSoft,
+			errs:   nil,
+			wanted: `<speak><prosody rate="medium" pitch="medium" volume="soft">text1</prosody><prosody rate="medium" pitch="medium" volume="soft">text2</prosody></speak>`,
 		},
 		{
-			name:     "fast, high, & medium",
-			rate:     prosody.RateFast,
-			pitch:    prosody.PitchHigh,
-			volume:   prosody.VolumeMedium,
-			errs:     nil,
-			expected: `<speak><prosody rate="fast" pitch="high" volume="medium">text1</prosody><prosody rate="fast" pitch="high" volume="medium">text2</prosody></speak>`,
+			name:   "fast, high, & medium",
+			rate:   prosody.RateFast,
+			pitch:  prosody.PitchHigh,
+			volume: prosody.VolumeMedium,
+			errs:   nil,
+			wanted: `<speak><prosody rate="fast" pitch="high" volume="medium">text1</prosody><prosody rate="fast" pitch="high" volume="medium">text2</prosody></speak>`,
 		},
 		{
-			name:     "x-fast, x-high, & loud",
-			rate:     prosody.RateXFast,
-			pitch:    prosody.PitchXHigh,
-			volume:   prosody.VolumeLoud,
-			errs:     nil,
-			expected: `<speak><prosody rate="x-fast" pitch="x-high" volume="loud">text1</prosody><prosody rate="x-fast" pitch="x-high" volume="loud">text2</prosody></speak>`,
+			name:   "x-fast, x-high, & loud",
+			rate:   prosody.RateXFast,
+			pitch:  prosody.PitchXHigh,
+			volume: prosody.VolumeLoud,
+			errs:   nil,
+			wanted: `<speak><prosody rate="x-fast" pitch="x-high" volume="loud">text1</prosody><prosody rate="x-fast" pitch="x-high" volume="loud">text2</prosody></speak>`,
 		},
 		{
-			name:     "x-fast, x-high, & x-loud",
-			rate:     prosody.RateXFast,
-			pitch:    prosody.PitchXHigh,
-			volume:   prosody.VolumeXLoud,
-			errs:     nil,
-			expected: `<speak><prosody rate="x-fast" pitch="x-high" volume="x-loud">text1</prosody><prosody rate="x-fast" pitch="x-high" volume="x-loud">text2</prosody></speak>`,
+			name:   "x-fast, x-high, & x-loud",
+			rate:   prosody.RateXFast,
+			pitch:  prosody.PitchXHigh,
+			volume: prosody.VolumeXLoud,
+			errs:   nil,
+			wanted: `<speak><prosody rate="x-fast" pitch="x-high" volume="x-loud">text1</prosody><prosody rate="x-fast" pitch="x-high" volume="x-loud">text2</prosody></speak>`,
 		},
 		{
-			name:     "custom",
-			rate:     prosody.Rate("custom rate"),
-			pitch:    prosody.Pitch("custom pitch"),
-			volume:   prosody.Volume("custom volume"),
-			errs:     nil,
-			expected: `<speak><prosody rate="custom rate" pitch="custom pitch" volume="custom volume">text1</prosody><prosody rate="custom rate" pitch="custom pitch" volume="custom volume">text2</prosody></speak>`,
+			name:   "custom",
+			rate:   prosody.Rate("custom rate"),
+			pitch:  prosody.Pitch("custom pitch"),
+			volume: prosody.Volume("custom volume"),
+			errs:   nil,
+			wanted: `<speak><prosody rate="custom rate" pitch="custom pitch" volume="custom volume">text1</prosody><prosody rate="custom rate" pitch="custom pitch" volume="custom volume">text2</prosody></speak>`,
 		},
 		{
-			name:     "onlyRate",
-			rate:     prosody.RateXSlow,
-			pitch:    nil,
-			volume:   nil,
-			errs:     nil,
-			expected: `<speak><prosody rate="x-slow">text1</prosody><prosody rate="x-slow">text2</prosody></speak>`,
+			name:   "onlyRate",
+			rate:   prosody.RateXSlow,
+			pitch:  nil,
+			volume: nil,
+			errs:   nil,
+			wanted: `<speak><prosody rate="x-slow">text1</prosody><prosody rate="x-slow">text2</prosody></speak>`,
 		},
 		{
-			name:     "onlyPitch",
-			rate:     nil,
-			pitch:    prosody.PitchXLow,
-			volume:   nil,
-			errs:     nil,
-			expected: `<speak><prosody pitch="x-low">text1</prosody><prosody pitch="x-low">text2</prosody></speak>`,
+			name:   "onlyPitch",
+			rate:   nil,
+			pitch:  prosody.PitchXLow,
+			volume: nil,
+			errs:   nil,
+			wanted: `<speak><prosody pitch="x-low">text1</prosody><prosody pitch="x-low">text2</prosody></speak>`,
 		},
 		{
-			name:     "onlyVolume",
-			rate:     nil,
-			pitch:    nil,
-			volume:   prosody.VolumeSilent,
-			errs:     nil,
-			expected: `<speak><prosody volume="silent">text1</prosody><prosody volume="silent">text2</prosody></speak>`,
+			name:   "onlyVolume",
+			rate:   nil,
+			pitch:  nil,
+			volume: prosody.VolumeSilent,
+			errs:   nil,
+			wanted: `<speak><prosody volume="silent">text1</prosody><prosody volume="silent">text2</prosody></speak>`,
 		},
 		{
-			name:     "percentageRate",
-			rate:     110,
-			pitch:    nil,
-			volume:   nil,
-			errs:     nil,
-			expected: `<speak><prosody rate="110%">text1</prosody><prosody rate="110%">text2</prosody></speak>`,
+			name:   "percentageRate",
+			rate:   110,
+			pitch:  nil,
+			volume: nil,
+			errs:   nil,
+			wanted: `<speak><prosody rate="110%">text1</prosody><prosody rate="110%">text2</prosody></speak>`,
 		},
 		{
-			name:     "positivePercentagePitch",
-			rate:     nil,
-			pitch:    10,
-			volume:   nil,
-			errs:     nil,
-			expected: `<speak><prosody pitch="+10%">text1</prosody><prosody pitch="+10%">text2</prosody></speak>`,
+			name:   "positivePercentagePitch",
+			rate:   nil,
+			pitch:  10,
+			volume: nil,
+			errs:   nil,
+			wanted: `<speak><prosody pitch="+10%">text1</prosody><prosody pitch="+10%">text2</prosody></speak>`,
 		},
 		{
-			name:     "negativePercentagePitch",
-			rate:     nil,
-			pitch:    -10,
-			volume:   nil,
-			errs:     nil,
-			expected: `<speak><prosody pitch="-10%">text1</prosody><prosody pitch="-10%">text2</prosody></speak>`,
+			name:   "negativePercentagePitch",
+			rate:   nil,
+			pitch:  -10,
+			volume: nil,
+			errs:   nil,
+			wanted: `<speak><prosody pitch="-10%">text1</prosody><prosody pitch="-10%">text2</prosody></speak>`,
 		},
 		{
-			name:     "positiveDbVolume",
-			rate:     nil,
-			pitch:    nil,
-			volume:   4,
-			errs:     nil,
-			expected: `<speak><prosody volume="+4dB">text1</prosody><prosody volume="+4dB">text2</prosody></speak>`,
+			name:   "positiveDbVolume",
+			rate:   nil,
+			pitch:  nil,
+			volume: 4,
+			errs:   nil,
+			wanted: `<speak><prosody volume="+4dB">text1</prosody><prosody volume="+4dB">text2</prosody></speak>`,
 		},
 		{
-			name:     "negativeDbVolume",
-			rate:     nil,
-			pitch:    nil,
-			volume:   -4,
-			errs:     nil,
-			expected: `<speak><prosody volume="-4dB">text1</prosody><prosody volume="-4dB">text2</prosody></speak>`,
+			name:   "negativeDbVolume",
+			rate:   nil,
+			pitch:  nil,
+			volume: -4,
+			errs:   nil,
+			wanted: `<speak><prosody volume="-4dB">text1</prosody><prosody volume="-4dB">text2</prosody></speak>`,
 		},
 		{
-			name:     "allNil",
-			rate:     nil,
-			pitch:    nil,
-			volume:   nil,
-			errs:     nil,
-			expected: `<speak><prosody>text1</prosody><prosody>text2</prosody></speak>`,
+			name:   "allNil",
+			rate:   nil,
+			pitch:  nil,
+			volume: nil,
+			errs:   nil,
+			wanted: `<speak><prosody>text1</prosody><prosody>text2</prosody></speak>`,
 		},
 		{
 			name:   "invalidRateType",
@@ -437,7 +437,7 @@ func TestBuilder_AppendProsody(t *testing.T) {
 				errors.New("unsupported rate type: must be either prosody.Rate or int"),
 				errors.New("unsupported rate type: must be either prosody.Rate or int"),
 			},
-			expected: `<speak></speak>`,
+			wanted: `<speak></speak>`,
 		},
 		{
 			name:   "invalidPitchType",
@@ -448,7 +448,7 @@ func TestBuilder_AppendProsody(t *testing.T) {
 				errors.New("unsupported pitch type: must be either prosody.Pitch or int"),
 				errors.New("unsupported pitch type: must be either prosody.Pitch or int"),
 			},
-			expected: `<speak></speak>`,
+			wanted: `<speak></speak>`,
 		},
 		{
 			name:   "invalidVolumeType",
@@ -459,7 +459,7 @@ func TestBuilder_AppendProsody(t *testing.T) {
 				errors.New("unsupported volume type: must be either prosody.Volume or int"),
 				errors.New("unsupported volume type: must be either prosody.Volume or int"),
 			},
-			expected: `<speak></speak>`,
+			wanted: `<speak></speak>`,
 		},
 	}
 
@@ -469,13 +469,13 @@ func TestBuilder_AppendProsody(t *testing.T) {
 
 			b.AppendProsody(test.rate, test.pitch, test.volume, "text1").AppendProsody(test.rate, test.pitch, test.volume, "text2")
 
-			actual, errs := b.Build()
-			if !errsEqual(test.errs, errs) {
-				t.Errorf("error mismatch: expected %v, got %v", test.errs, errs)
+			got, errs := b.Build()
+			if !errsEqual(errs, test.errs) {
+				t.Errorf("error mismatch: got: %+v, wanted: %+v", errs, test.errs)
 			}
 
-			if actual != test.expected {
-				t.Errorf("output mismatch: expected %s, got %s", test.expected, actual)
+			if got != test.wanted {
+				t.Errorf("output mismatch: got: %s, wanted: %s", got, test.wanted)
 			}
 		})
 	}
@@ -487,14 +487,14 @@ func TestBuilder_AppendSentence(t *testing.T) {
 	b.AppendSentence("text1")
 	b.AppendSentence("text2")
 
-	actual, errs := b.Build()
+	got, errs := b.Build()
 	if !errsEqual(nil, errs) {
-		t.Errorf("error mismatch: expected nil, got %v", errs)
+		t.Errorf("error mismatch: got: %+v, wanted: nil", errs)
 	}
 
-	expected := `<speak><s>text1</s><s>text2</s></speak>`
-	if actual != expected {
-		t.Errorf("output mismatch: expected %s, got %s", expected, actual)
+	wanted := `<speak><s>text1</s><s>text2</s></speak>`
+	if got != wanted {
+		t.Errorf("output mismatch: got: %s, wanted: %s", got, wanted)
 	}
 }
 
@@ -504,14 +504,14 @@ func TestBuilder_AppendSubstitution(t *testing.T) {
 	b.AppendSubstitution("alias1", "text1")
 	b.AppendSubstitution("alias2", "text2")
 
-	actual, errs := b.Build()
+	got, errs := b.Build()
 	if !errsEqual(nil, errs) {
-		t.Errorf("error mismatch: expected nil, got %v", errs)
+		t.Errorf("error mismatch: got: %+v, wanted: nil", errs)
 	}
 
-	expected := `<speak><sub alias="alias1">text1</sub><sub alias="alias2">text2</sub></speak>`
-	if actual != expected {
-		t.Errorf("output mismatch: expected %s, got %s", expected, actual)
+	wanted := `<speak><sub alias="alias1">text1</sub><sub alias="alias2">text2</sub></speak>`
+	if got != wanted {
+		t.Errorf("output mismatch: got: %s, wanted: %s", got, wanted)
 	}
 }
 
@@ -537,10 +537,10 @@ func TestAppendErrorConcurrency(t *testing.T) {
 	wg.Wait()
 
 	_, errs := b.Build()
-	actual := len(errs)
-	expected := numOfWorkers * numOfErrorsPerWorker
-	if actual != expected {
-		t.Errorf("error count mismatch: expected %d, got %d", actual, expected)
+	got := len(errs)
+	wanted := numOfWorkers * numOfErrorsPerWorker
+	if got != wanted {
+		t.Errorf("error count mismatch: got: %d, wanted: %d", got, wanted)
 	}
 }
 


### PR DESCRIPTION
Note: This code change assumes the `Add metadata to customskill handlers` commit is going to be pulled in from #36. Sorry for the noise from that commit.

A few little changes here:
- Instead of manually naming tests and outputting the name in each `Errorf` you can just use `t.Run(name, ...)`. I've applied this to all tests.
- Now that each subtest is running it it's own function we can restore mocked function with `defer` so that has been added to all tests that use mocked functions.
- Finally migrated all tests to use the `got/wanted` over `got/expected` (or similar). Mostly just for standardization.