### PR TITLE
Add support for reading the Request's locale

### DIFF
--- a/skillserver/echo.go
+++ b/skillserver/echo.go
@@ -57,6 +57,27 @@ func (this *EchoRequest) AllSlots() map[string]EchoSlot {
 	return this.Request.Intent.Slots
 }
 
+// Locale returns the locale specified in the request.
+//
+// If `locales` is provided, the first matching locale will be returned,
+// falling back to the first provided value if none match the request.
+//
+// (Matching is performed via a strict string comparison. For more
+// advanced matching, you may want to use the "golang.org/x/text/language"
+// library instead.)
+func (this *EchoRequest) Locale(locales ...string) string {
+	if len(locales) > 0 {
+		for _, locale := range locales {
+			if this.Request.Locale == locale {
+				return locale
+			}
+		}
+		return locales[0]
+	}
+
+	return this.Request.Locale
+}
+
 // Response Functions
 func NewEchoResponse() *EchoResponse {
 	er := &EchoResponse{
@@ -204,6 +225,7 @@ type EchoReqBody struct {
 	Timestamp string     `json:"timestamp"`
 	Intent    EchoIntent `json:"intent,omitempty"`
 	Reason    string     `json:"reason,omitempty"`
+	Locale    string     `json:"locale,omitempty"`
 }
 
 type EchoIntent struct {

--- a/skillserver/echo.go
+++ b/skillserver/echo.go
@@ -58,23 +58,7 @@ func (this *EchoRequest) AllSlots() map[string]EchoSlot {
 }
 
 // Locale returns the locale specified in the request.
-//
-// If `locales` is provided, the first matching locale will be returned,
-// falling back to the first provided value if none match the request.
-//
-// (Matching is performed via a strict string comparison. For more
-// advanced matching, you may want to use the "golang.org/x/text/language"
-// library instead.)
-func (this *EchoRequest) Locale(locales ...string) string {
-	if len(locales) > 0 {
-		for _, locale := range locales {
-			if this.Request.Locale == locale {
-				return locale
-			}
-		}
-		return locales[0]
-	}
-
+func (this *EchoRequest) Locale() string {
 	return this.Request.Locale
 }
 


### PR DESCRIPTION
I noticed that the `locale` value was not being parsed nor exposed, so I've added the property and a very simple getter function with fallback support.