### PR TITLE
Extended EchoSlot struct by including a new property named "Resolutions"

### DIFF
--- a/skillserver/echo.go
+++ b/skillserver/echo.go
@@ -46,11 +46,21 @@ func (this *EchoRequest) GetIntentName() string {
 }
 
 func (this *EchoRequest) GetSlotValue(slotName string) (string, error) {
-	if _, ok := this.Request.Intent.Slots[slotName]; ok {
-		return this.Request.Intent.Slots[slotName].Value, nil
+	slot, err := this.GetSlot(slotName)
+
+	if err != nil {
+		return "", err
 	}
 
-	return "", errors.New("Slot name not found.")
+	return slot.Value, nil
+}
+
+func (this *EchoRequest) GetSlot(slotName string) (EchoSlot, error) {
+	if _, ok := this.Request.Intent.Slots[slotName]; ok {
+		return this.Request.Intent.Slots[slotName], nil
+	}
+
+	return EchoSlot{}, errors.New("Slot name not found.")
 }
 
 func (this *EchoRequest) AllSlots() map[string]EchoSlot {
@@ -218,8 +228,24 @@ type EchoIntent struct {
 }
 
 type EchoSlot struct {
-	Name  string `json:"name"`
-	Value string `json:"value"`
+	Name        string         `json:"name"`
+	Value       string         `json:"value"`
+	Resolutions EchoResolution `json:"resolutions"`
+}
+
+type EchoResolution struct {
+	ResolutionsPerAuthority []EchoResolutionPerAuthority `json:"resolutionsPerAuthority"`
+}
+
+type EchoResolutionPerAuthority struct {
+	Authority string `json:"authority"`
+	Status    struct {
+		Code string `json:"code"`
+	} `json:"status"`
+	Values []map[string]struct {
+		Name string `json:"name"`
+		ID   string `json:"id"`
+	} `json:"values"`
 }
 
 // Response Types


### PR DESCRIPTION
With the introduction of synonyms and IDs for Slot Type Values the
property "resolutions" was added to the IntentRequest type. More info
here: https://developer.amazon.com/docs/custom-skills/request-types-reference.html#intentrequest
Also, added a new method to get the full EchoSlot so Resolutions could be accessed.

An example of how the EchoSlot looks now:

```
{
	"name": "slotName",
	"value": "slotValueSynonym",
	"resolutions": {
		"resolutionsPerAuthority": [
			{
				"authority": "amzn1.er-authority.echo-sdk.amzn1.ask.skill.xxxxxxx.SlotName",
				"status": {
					"code": "ER_SUCCESS_MATCH"
				},
				"values": [
					{
						"value": {
							"name": "originalSlotValue",
							"id": "xxxxxxxx"
						}
					}
				]
			}
		]
	}
}
```

Would help resolve issues like:
https://forums.developer.amazon.com/questions/76612/synonyms-not-resolving-to-canonical-slot-values-is.html
