### PR TITLE
Add support for Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: go
+
+matrix:
+  include:
+    - go: "tip"
+    - go: "1.x"
+    - go: "1.10"
+    - go: "1.9"
+    - go: "1.8"
+  allow_failures:
+    - go: tip

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ## `go-alexa`: A Go toolset for creating Amazon Alexa Skills
 
+![build status badge](https://travis-ci.org/mikeflynn/go-alexa.svg?branch=master)
+
 The Amazon Echo, with it's voice assitant Alexa, is a surprisingly amazing tool. Having the power of voice recognition tied to the web ready at any time is quite powerful and now that Amazon has opened up a developer platform it's even more exciting!
 
 Amazon has supplied packages for Java and Node.js (tied to the AWS Lamda platform) but I wanted to develop my skills in Go. As I moved through the process making my app work with Amazon's spec, a simple web framework that took care all the heavy lifting on security and crafting the response object formed. I'm looking forward to more Go-based tools getting created and living in this `go-alexa` bucket but for now the `skillserver` is the first tool.


### PR DESCRIPTION
This code change adds support (a config file) for Travis CI builds. It also adds a build badge to the README. [Example of it building my fork](https://travis-ci.org/harrisonhjones/go-alexa).

To get this to work you will also need to:

1. Head over to [Travis CI](https://travis-ci.org/) and sign-in with your GitHub account
1. Once signed in you should get a list of your repos. Locate `go-alexa` and select it.
1. Locate the blue green "Activate repository" button. Press it and follow any additional steps to get it setup.
1. Travis CI will automatically start building new pull requests and commits (this can be customized). Once this PR is merged all new code will be built (using `go test`) against go 1.8, 1.9, 1.10, 1.x, and "tip". The build badge on the README will reflect the current state of building master.